### PR TITLE
fix(ios): find embedded Flutter view for cursor lock

### DIFF
--- a/ios/Classes/HardwareSimulatorPlugin.swift
+++ b/ios/Classes/HardwareSimulatorPlugin.swift
@@ -132,11 +132,26 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       guard let window = UIApplication.shared.keyWindow else { print("no window"); return nil }
       guard let rvc = window.rootViewController else { print("no rvc"); return nil }
       if let rvc = rvc as? HomeIndicatorAwareFlutterViewController { return rvc }
-      guard let fvc = rvc as? FlutterViewController else { return nil }
+      guard let fvc = findFlutterViewController(from: rvc) else { return nil }
       object_setClass(fvc, HomeIndicatorAwareFlutterViewController.self)
       let newController = fvc as! HomeIndicatorAwareFlutterViewController
-      window.rootViewController = newController as UIViewController?
       return newController
+    }
+
+    private func findFlutterViewController(from controller: UIViewController) -> FlutterViewController? {
+      if let fvc = controller as? FlutterViewController {
+        return fvc
+      }
+      for child in controller.children {
+        if let fvc = findFlutterViewController(from: child) {
+          return fvc
+        }
+      }
+      if let presented = controller.presentedViewController,
+         let fvc = findFlutterViewController(from: presented) {
+        return fvc
+      }
+      return nil
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {


### PR DESCRIPTION
## Summary
- make iOS cursor-lock controller lookup recurse through child/presented view controllers
- support CloudPlayPlus's NativeOverlayViewController root while keeping the existing lockCursor behavior

## Validation
- from parent app: flutter analyze
- from parent app: LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 flutter build ios --debug --no-codesign

## Notes
- This PR is required by the parent cloudplayplus PR so iOS lockCursor reaches the embedded FlutterViewController.