### PR TITLE
fix(linux): use inputtino for mouse simulation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/inputtino"]
+	path = third_party/inputtino
+	url = https://github.com/games-on-whales/inputtino.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This plugin simulates mouse & keyboard input. Currently it is not well documented. 
 
-Current it supports to simulate: mouse & keyboard for Windows/MacOS. XBOX Game Controller for windows. See the example for details.
+Current it supports to simulate: mouse & keyboard for Windows/macOS/Linux (Linux mouse uses uinput via inputtino; Linux keyboard still requires X11 + XTest). XBOX Game Controller for windows. See the example for details.
 
 Any pull request is welcome. It is designed for https://github.com/zhuhaichao518/cloudplayplus_stone.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,17 @@ This plugin simulates mouse & keyboard input. Currently it is not well documente
 
 Current it supports to simulate: mouse & keyboard for Windows/macOS/Linux (Linux mouse uses uinput via inputtino; Linux keyboard still requires X11 + XTest). XBOX Game Controller for windows. See the example for details.
 
+Linux uinput permission setup:
+
+```bash
+sudo install -m 0644 linux/udev/rules.d/60-cloudplayplus-hardware-simulator.rules /etc/udev/rules.d/
+sudo groupadd -f input
+sudo usermod -aG input "$USER"
+sudo modprobe uinput
+sudo udevadm control --reload-rules
+sudo udevadm trigger --property-match=DEVNAME=/dev/uinput
+```
+
+Log out and back in after adding your user to the `input` group.
+
 Any pull request is welcome. It is designed for https://github.com/zhuhaichao518/cloudplayplus_stone.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,7 @@ Current it supports to simulate: mouse & keyboard for Windows/macOS/Linux (Linux
 Linux uinput permission setup:
 
 ```bash
-sudo install -m 0644 linux/udev/rules.d/60-cloudplayplus-hardware-simulator.rules /etc/udev/rules.d/
-sudo groupadd -f input
-sudo usermod -aG input "$USER"
-sudo modprobe uinput
-sudo udevadm control --reload-rules
-sudo udevadm trigger --property-match=DEVNAME=/dev/uinput
+./scripts/setup_linux_input_permissions.sh
 ```
 
 Log out and back in after adding your user to the `input` group.

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -41,6 +41,42 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
+pkg_check_modules(LIBEVDEV QUIET libevdev)
+if(LIBEVDEV_FOUND)
+  set(LIBEVDEV_CUSTOM_INCLUDE_DIR "${LIBEVDEV_INCLUDE_DIRS}")
+  set(LIBEVDEV_CUSTOM_LIBRARY PkgConfig::LIBEVDEV)
+else()
+  include(ExternalProject)
+  set(LIBEVDEV_VERSION 1.13.2)
+  ExternalProject_Add(libevdev
+    URL https://www.freedesktop.org/software/libevdev/libevdev-${LIBEVDEV_VERSION}.tar.xz
+    PREFIX libevdev-${LIBEVDEV_VERSION}
+    BUILD_IN_SOURCE 1
+    BUILD_BYPRODUCTS <SOURCE_DIR>/libevdev/.libs/libevdev.a
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CFLAGS=-fPIC <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+    BUILD_COMMAND make
+    INSTALL_COMMAND "")
+  ExternalProject_Get_Property(libevdev SOURCE_DIR)
+  set(LIBEVDEV_CUSTOM_INCLUDE_DIR "${SOURCE_DIR}")
+  set(LIBEVDEV_CUSTOM_LIBRARY "${SOURCE_DIR}/libevdev/.libs/libevdev.a")
+endif()
+
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(USE_UHID OFF)
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../third_party/inputtino"
+  "${CMAKE_CURRENT_BINARY_DIR}/inputtino")
+set_target_properties(libinputtino PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(NOT LIBEVDEV_FOUND)
+  add_dependencies(libinputtino libevdev)
+  add_dependencies(${PLUGIN_NAME} libevdev)
+endif()
+target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_17)
+target_link_libraries(${PLUGIN_NAME} PRIVATE inputtino::libinputtino)
+
+pkg_check_modules(X11 REQUIRED IMPORTED_TARGET x11 xtst xrandr)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::X11)
+
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an
 # external build triggered from this build file.
@@ -84,6 +120,8 @@ apply_standard_settings(${TEST_RUNNER})
 target_include_directories(${TEST_RUNNER} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(${TEST_RUNNER} PRIVATE flutter)
 target_link_libraries(${TEST_RUNNER} PRIVATE PkgConfig::GTK)
+target_link_libraries(${TEST_RUNNER} PRIVATE inputtino::libinputtino)
+target_link_libraries(${TEST_RUNNER} PRIVATE PkgConfig::X11)
 target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main gmock)
 
 # Enable automatic test discovery.

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
-pkg_check_modules(LIBEVDEV QUIET libevdev)
+pkg_check_modules(LIBEVDEV QUIET IMPORTED_TARGET libevdev)
 if(LIBEVDEV_FOUND)
   set(LIBEVDEV_CUSTOM_INCLUDE_DIR "${LIBEVDEV_INCLUDE_DIRS}")
   set(LIBEVDEV_CUSTOM_LIBRARY PkgConfig::LIBEVDEV)

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -39,12 +40,22 @@ struct MonitorBounds {
   int height;
 };
 
+enum class MouseMode {
+  kRelative,
+  kAbsolute,
+};
+
 std::mutex g_input_mutex;
 std::mutex g_mouse_mutex;
 std::set<KeyCode> g_pressed_keys;
-std::set<inputtino::Mouse::MOUSE_BUTTON> g_pressed_mouse_buttons;
+std::map<inputtino::Mouse::MOUSE_BUTTON, MouseMode> g_pressed_mouse_buttons;
 std::unique_ptr<inputtino::Mouse> g_mouse;
 std::string g_mouse_error;
+MouseMode g_current_mouse_mode = MouseMode::kRelative;
+int g_last_abs_x = 0;
+int g_last_abs_y = 0;
+int g_last_abs_width = 1;
+int g_last_abs_height = 1;
 
 FlMethodResponse* success_null() {
   return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
@@ -230,6 +241,16 @@ inputtino::Mouse* get_mouse() {
   return g_mouse.get();
 }
 
+void set_mouse_mode(inputtino::Mouse* mouse, MouseMode mode) {
+  if (mode == MouseMode::kAbsolute) {
+    mouse->move_abs(g_last_abs_x, g_last_abs_y, g_last_abs_width,
+                    g_last_abs_height);
+  } else {
+    mouse->move(0, 0);
+  }
+  g_current_mouse_mode = mode;
+}
+
 KeySym windows_vk_to_keysym(int vk) {
   if (vk >= 0x41 && vk <= 0x5A) {
     return XK_a + (vk - 0x41);
@@ -361,7 +382,12 @@ FlMethodResponse* perform_mouse_move_relative(FlValue* args) {
   if (mouse == nullptr) {
     return linux_mouse_error();
   }
-  mouse->move(static_cast<int>(std::round(x)), static_cast<int>(std::round(y)));
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    mouse->move(static_cast<int>(std::round(x)),
+                static_cast<int>(std::round(y)));
+    g_current_mouse_mode = MouseMode::kRelative;
+  }
   return success_null();
 }
 
@@ -395,7 +421,15 @@ FlMethodResponse* perform_mouse_move_absolute(FlValue* args) {
       monitor.x - root.x + static_cast<int>(std::round(x * (monitor.width - 1)));
   int target_y =
       monitor.y - root.y + static_cast<int>(std::round(y * (monitor.height - 1)));
-  mouse->move_abs(target_x, target_y, root.width, root.height);
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    mouse->move_abs(target_x, target_y, root.width, root.height);
+    g_current_mouse_mode = MouseMode::kAbsolute;
+    g_last_abs_x = target_x;
+    g_last_abs_y = target_y;
+    g_last_abs_width = root.width;
+    g_last_abs_height = root.height;
+  }
   return success_null();
 }
 
@@ -418,15 +452,16 @@ FlMethodResponse* perform_mouse_button(FlValue* args) {
   {
     std::lock_guard<std::mutex> lock(g_input_mutex);
     if (is_down) {
-      g_pressed_mouse_buttons.insert(button);
+      g_pressed_mouse_buttons[button] = g_current_mouse_mode;
+      mouse->press(button);
     } else {
-      g_pressed_mouse_buttons.erase(button);
+      auto pressed_button = g_pressed_mouse_buttons.find(button);
+      if (pressed_button != g_pressed_mouse_buttons.end()) {
+        set_mouse_mode(mouse, pressed_button->second);
+        g_pressed_mouse_buttons.erase(pressed_button);
+      }
+      mouse->release(button);
     }
-  }
-  if (is_down) {
-    mouse->press(button);
-  } else {
-    mouse->release(button);
   }
   return success_null();
 }
@@ -447,9 +482,11 @@ FlMethodResponse* perform_mouse_scroll(FlValue* args) {
   int vertical_distance = static_cast<int>(std::round(dy));
   int horizontal_distance = static_cast<int>(std::round(dx));
   if (vertical_distance != 0) {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
     mouse->vertical_scroll(vertical_distance);
   }
   if (horizontal_distance != 0) {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
     mouse->horizontal_scroll(horizontal_distance);
   }
   return success_null();
@@ -463,27 +500,55 @@ FlMethodResponse* get_monitor_count() {
   return success_int(static_cast<int>(get_monitors(display.get()).size()));
 }
 
+FlMethodResponse* clear_all_pressed_mouse_buttons() {
+  std::map<inputtino::Mouse::MOUSE_BUTTON, MouseMode> buttons;
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    buttons.swap(g_pressed_mouse_buttons);
+  }
+  if (buttons.empty()) {
+    return nullptr;
+  }
+  auto* mouse = get_mouse();
+  if (mouse == nullptr) {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    g_pressed_mouse_buttons.insert(buttons.begin(), buttons.end());
+    return linux_mouse_error();
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    for (const auto& button : buttons) {
+      set_mouse_mode(mouse, button.second);
+      mouse->release(button.first);
+    }
+  }
+  return nullptr;
+}
+
 FlMethodResponse* clear_all_pressed_events() {
+  if (auto* mouse_error = clear_all_pressed_mouse_buttons()) {
+    return mouse_error;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    if (g_pressed_keys.empty()) {
+      return success_null();
+    }
+  }
+
   XDisplay display;
   if (!display.supports_xtest()) {
     return linux_display_error();
   }
 
   std::set<KeyCode> keys;
-  std::set<inputtino::Mouse::MOUSE_BUTTON> buttons;
   {
     std::lock_guard<std::mutex> lock(g_input_mutex);
     keys.swap(g_pressed_keys);
-    buttons.swap(g_pressed_mouse_buttons);
   }
   for (KeyCode key : keys) {
     XTestFakeKeyEvent(display.get(), key, False, CurrentTime);
-  }
-  auto* mouse = get_mouse();
-  if (mouse != nullptr) {
-    for (auto button : buttons) {
-      mouse->release(button);
-    }
   }
   XFlush(display.get());
   return success_null();

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -78,12 +78,16 @@ FlMethodResponse* linux_display_error() {
 }
 
 FlMethodResponse* linux_mouse_error() {
+  std::string message =
+      "Linux mouse simulation requires permission to create uinput devices. "
+      "Install linux/udev/rules.d/60-cloudplayplus-hardware-simulator.rules "
+      "or grant the current user access to /dev/uinput.";
+  if (!g_mouse_error.empty()) {
+    message += " inputtino error: ";
+    message += g_mouse_error;
+  }
   return FL_METHOD_RESPONSE(fl_method_error_response_new(
-      "UINPUT_UNAVAILABLE",
-      g_mouse_error.empty()
-          ? "Linux mouse simulation requires permission to create uinput devices."
-          : g_mouse_error.c_str(),
-      nullptr));
+      "UINPUT_UNAVAILABLE", message.c_str(), nullptr));
 }
 
 class XDisplay {

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -2,9 +2,21 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
+#include <inputtino/input.hpp>
 #include <sys/utsname.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/XTest.h>
+#include <X11/extensions/Xrandr.h>
+#include <X11/keysym.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstring>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
 
 #include "hardware_simulator_plugin_private.h"
 
@@ -18,6 +30,463 @@ struct _HardwareSimulatorPlugin {
 
 G_DEFINE_TYPE(HardwareSimulatorPlugin, hardware_simulator_plugin, g_object_get_type())
 
+namespace {
+
+struct MonitorBounds {
+  int x;
+  int y;
+  int width;
+  int height;
+};
+
+std::mutex g_input_mutex;
+std::mutex g_mouse_mutex;
+std::set<KeyCode> g_pressed_keys;
+std::set<inputtino::Mouse::MOUSE_BUTTON> g_pressed_mouse_buttons;
+std::unique_ptr<inputtino::Mouse> g_mouse;
+std::string g_mouse_error;
+
+FlMethodResponse* success_null() {
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+}
+
+FlMethodResponse* success_bool(bool value) {
+  g_autoptr(FlValue) result = fl_value_new_bool(value);
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+}
+
+FlMethodResponse* success_int(int value) {
+  g_autoptr(FlValue) result = fl_value_new_int(value);
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+}
+
+FlMethodResponse* bad_args(const char* message) {
+  return FL_METHOD_RESPONSE(fl_method_error_response_new(
+      "BAD_ARGS", message, nullptr));
+}
+
+FlMethodResponse* unsupported(const char* message) {
+  return FL_METHOD_RESPONSE(fl_method_error_response_new(
+      "UNSUPPORTED", message, nullptr));
+}
+
+FlMethodResponse* linux_display_error() {
+  return FL_METHOD_RESPONSE(fl_method_error_response_new(
+      "DISPLAY_UNAVAILABLE",
+      "Linux hardware simulation requires an X11 DISPLAY with XTest support.",
+      nullptr));
+}
+
+FlMethodResponse* linux_mouse_error() {
+  return FL_METHOD_RESPONSE(fl_method_error_response_new(
+      "UINPUT_UNAVAILABLE",
+      g_mouse_error.empty()
+          ? "Linux mouse simulation requires permission to create uinput devices."
+          : g_mouse_error.c_str(),
+      nullptr));
+}
+
+class XDisplay {
+ public:
+  XDisplay() : display_(XOpenDisplay(nullptr)) {}
+  ~XDisplay() {
+    if (display_ != nullptr) {
+      XCloseDisplay(display_);
+    }
+  }
+
+  XDisplay(const XDisplay&) = delete;
+  XDisplay& operator=(const XDisplay&) = delete;
+
+  Display* get() const { return display_; }
+
+  bool supports_xtest() const {
+    if (display_ == nullptr) {
+      return false;
+    }
+    int event_base = 0;
+    int error_base = 0;
+    int major = 0;
+    int minor = 0;
+    return XTestQueryExtension(display_, &event_base, &error_base, &major,
+                               &minor) == True;
+  }
+
+ private:
+  Display* display_;
+};
+
+double get_double_arg(FlValue* args, const char* key, bool* ok) {
+  if (args == nullptr) {
+    *ok = false;
+    return 0.0;
+  }
+  FlValue* value = fl_value_lookup_string(args, key);
+  if (value == nullptr) {
+    *ok = false;
+    return 0.0;
+  }
+  if (fl_value_get_type(value) == FL_VALUE_TYPE_FLOAT) {
+    return fl_value_get_float(value);
+  }
+  if (fl_value_get_type(value) == FL_VALUE_TYPE_INT) {
+    return static_cast<double>(fl_value_get_int(value));
+  }
+  *ok = false;
+  return 0.0;
+}
+
+int get_int_arg(FlValue* args, const char* key, bool* ok) {
+  if (args == nullptr) {
+    *ok = false;
+    return 0;
+  }
+  FlValue* value = fl_value_lookup_string(args, key);
+  if (value == nullptr || fl_value_get_type(value) != FL_VALUE_TYPE_INT) {
+    *ok = false;
+    return 0;
+  }
+  return static_cast<int>(fl_value_get_int(value));
+}
+
+bool get_bool_arg(FlValue* args, const char* key, bool* ok) {
+  if (args == nullptr) {
+    *ok = false;
+    return false;
+  }
+  FlValue* value = fl_value_lookup_string(args, key);
+  if (value == nullptr || fl_value_get_type(value) != FL_VALUE_TYPE_BOOL) {
+    *ok = false;
+    return false;
+  }
+  return fl_value_get_bool(value);
+}
+
+std::vector<MonitorBounds> get_monitors(Display* display) {
+  std::vector<MonitorBounds> monitors;
+  Window root = DefaultRootWindow(display);
+  int monitor_count = 0;
+  XRRMonitorInfo* xrr_monitors =
+      XRRGetMonitors(display, root, True, &monitor_count);
+  if (xrr_monitors != nullptr) {
+    for (int i = 0; i < monitor_count; ++i) {
+      if (xrr_monitors[i].noutput <= 0) {
+        continue;
+      }
+      monitors.push_back({xrr_monitors[i].x, xrr_monitors[i].y,
+                          xrr_monitors[i].width, xrr_monitors[i].height});
+    }
+    XRRFreeMonitors(xrr_monitors);
+  }
+
+  if (monitors.empty()) {
+    int screen = DefaultScreen(display);
+    monitors.push_back({0, 0, DisplayWidth(display, screen),
+                        DisplayHeight(display, screen)});
+  }
+  return monitors;
+}
+
+MonitorBounds get_root_bounds(const std::vector<MonitorBounds>& monitors) {
+  if (monitors.empty()) {
+    return {0, 0, 1, 1};
+  }
+  int left = monitors.front().x;
+  int top = monitors.front().y;
+  int right = monitors.front().x + monitors.front().width;
+  int bottom = monitors.front().y + monitors.front().height;
+  for (const auto& monitor : monitors) {
+    left = std::min(left, monitor.x);
+    top = std::min(top, monitor.y);
+    right = std::max(right, monitor.x + monitor.width);
+    bottom = std::max(bottom, monitor.y + monitor.height);
+  }
+  return {left, top, std::max(1, right - left), std::max(1, bottom - top)};
+}
+
+inputtino::Mouse* get_mouse() {
+  std::lock_guard<std::mutex> lock(g_mouse_mutex);
+  if (g_mouse) {
+    return g_mouse.get();
+  }
+
+  auto mouse = inputtino::Mouse::create({
+      .name = "CloudPlayPlus Mouse passthrough",
+      .vendor_id = 0xBEEF,
+      .product_id = 0xDEAD,
+      .version = 0x111,
+  });
+  if (!mouse) {
+    g_mouse_error = mouse.getErrorMessage();
+    return nullptr;
+  }
+
+  g_mouse = std::make_unique<inputtino::Mouse>(std::move(*mouse));
+  g_mouse_error.clear();
+  return g_mouse.get();
+}
+
+KeySym windows_vk_to_keysym(int vk) {
+  if (vk >= 0x41 && vk <= 0x5A) {
+    return XK_a + (vk - 0x41);
+  }
+  if (vk >= 0x30 && vk <= 0x39) {
+    return XK_0 + (vk - 0x30);
+  }
+  if (vk >= 0x70 && vk <= 0x7B) {
+    return XK_F1 + (vk - 0x70);
+  }
+  if (vk >= 0x60 && vk <= 0x69) {
+    return XK_KP_0 + (vk - 0x60);
+  }
+
+  switch (vk) {
+    case 0x08: return XK_BackSpace;
+    case 0x09: return XK_Tab;
+    case 0x0D: return XK_Return;
+    case 0x14: return XK_Caps_Lock;
+    case 0x1B: return XK_Escape;
+    case 0x20: return XK_space;
+    case 0x21: return XK_Page_Up;
+    case 0x22: return XK_Page_Down;
+    case 0x23: return XK_End;
+    case 0x24: return XK_Home;
+    case 0x25: return XK_Left;
+    case 0x26: return XK_Up;
+    case 0x27: return XK_Right;
+    case 0x28: return XK_Down;
+    case 0x2D: return XK_Insert;
+    case 0x2E: return XK_Delete;
+    case 0x5B: return XK_Super_L;
+    case 0x5C: return XK_Super_R;
+    case 0x5D: return XK_Menu;
+    case 0x6A: return XK_KP_Multiply;
+    case 0x6B: return XK_KP_Add;
+    case 0x6D: return XK_KP_Subtract;
+    case 0x6E: return XK_KP_Decimal;
+    case 0x6F: return XK_KP_Divide;
+    case 0xA0: return XK_Shift_L;
+    case 0xA1: return XK_Shift_R;
+    case 0xA2: return XK_Control_L;
+    case 0xA3: return XK_Control_R;
+    case 0xA4: return XK_Alt_L;
+    case 0xA5: return XK_Alt_R;
+    case 0xBA: return XK_semicolon;
+    case 0xBB: return XK_equal;
+    case 0xBC: return XK_comma;
+    case 0xBD: return XK_minus;
+    case 0xBE: return XK_period;
+    case 0xBF: return XK_slash;
+    case 0xC0: return XK_grave;
+    case 0xDB: return XK_bracketleft;
+    case 0xDC: return XK_backslash;
+    case 0xDD: return XK_bracketright;
+    case 0xDE: return XK_apostrophe;
+    default: return NoSymbol;
+  }
+}
+
+bool mouse_button_to_inputtino(int button_id,
+                               inputtino::Mouse::MOUSE_BUTTON* button) {
+  switch (button_id) {
+    case 1:
+      *button = inputtino::Mouse::LEFT;
+      return true;
+    case 2:
+      *button = inputtino::Mouse::MIDDLE;
+      return true;
+    case 3:
+      *button = inputtino::Mouse::RIGHT;
+      return true;
+    case 4:
+      *button = inputtino::Mouse::SIDE;
+      return true;
+    case 5:
+      *button = inputtino::Mouse::EXTRA;
+      return true;
+    default:
+      return false;
+  }
+}
+
+FlMethodResponse* perform_key_event(FlValue* args) {
+  bool ok = true;
+  int code = get_int_arg(args, "code", &ok);
+  bool is_down = get_bool_arg(args, "isDown", &ok);
+  if (!ok) {
+    return bad_args("Missing or incorrect arguments for KeyPress");
+  }
+
+  XDisplay display;
+  if (!display.supports_xtest()) {
+    return linux_display_error();
+  }
+  KeySym keysym = windows_vk_to_keysym(code);
+  if (keysym == NoSymbol) {
+    return unsupported("Unsupported Windows virtual-key code.");
+  }
+  KeyCode keycode = XKeysymToKeycode(display.get(), keysym);
+  if (keycode == 0) {
+    return unsupported("No X11 keycode for requested key.");
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    if (is_down) {
+      g_pressed_keys.insert(keycode);
+    } else {
+      g_pressed_keys.erase(keycode);
+    }
+  }
+  XTestFakeKeyEvent(display.get(), keycode, is_down ? True : False,
+                    CurrentTime);
+  XFlush(display.get());
+  return success_null();
+}
+
+FlMethodResponse* perform_mouse_move_relative(FlValue* args) {
+  bool ok = true;
+  double x = get_double_arg(args, "x", &ok);
+  double y = get_double_arg(args, "y", &ok);
+  (void)get_int_arg(args, "screenId", &ok);
+  if (!ok) {
+    return bad_args("Missing or incorrect arguments for mouseMoveR");
+  }
+
+  auto* mouse = get_mouse();
+  if (mouse == nullptr) {
+    return linux_mouse_error();
+  }
+  mouse->move(static_cast<int>(std::round(x)), static_cast<int>(std::round(y)));
+  return success_null();
+}
+
+FlMethodResponse* perform_mouse_move_absolute(FlValue* args) {
+  bool ok = true;
+  double x = get_double_arg(args, "x", &ok);
+  double y = get_double_arg(args, "y", &ok);
+  int screen_id = get_int_arg(args, "screenId", &ok);
+  if (!ok) {
+    return bad_args("Missing or incorrect arguments for mouseMoveA");
+  }
+
+  auto* mouse = get_mouse();
+  if (mouse == nullptr) {
+    return linux_mouse_error();
+  }
+
+  XDisplay display;
+  if (display.get() == nullptr) {
+    return linux_display_error();
+  }
+  auto monitors = get_monitors(display.get());
+  if (screen_id < 0 || screen_id >= static_cast<int>(monitors.size())) {
+    return bad_args("Invalid screenId for mouseMoveA");
+  }
+  const auto root = get_root_bounds(monitors);
+  const auto& monitor = monitors[screen_id];
+  x = std::max(0.0, std::min(1.0, x));
+  y = std::max(0.0, std::min(1.0, y));
+  int target_x =
+      monitor.x - root.x + static_cast<int>(std::round(x * (monitor.width - 1)));
+  int target_y =
+      monitor.y - root.y + static_cast<int>(std::round(y * (monitor.height - 1)));
+  mouse->move_abs(target_x, target_y, root.width, root.height);
+  return success_null();
+}
+
+FlMethodResponse* perform_mouse_button(FlValue* args) {
+  bool ok = true;
+  int button_id = get_int_arg(args, "buttonId", &ok);
+  bool is_down = get_bool_arg(args, "isDown", &ok);
+  if (!ok) {
+    return bad_args("Missing or incorrect arguments for mousePress");
+  }
+  inputtino::Mouse::MOUSE_BUTTON button;
+  if (!mouse_button_to_inputtino(button_id, &button)) {
+    return unsupported("Unsupported mouse button id.");
+  }
+
+  auto* mouse = get_mouse();
+  if (mouse == nullptr) {
+    return linux_mouse_error();
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    if (is_down) {
+      g_pressed_mouse_buttons.insert(button);
+    } else {
+      g_pressed_mouse_buttons.erase(button);
+    }
+  }
+  if (is_down) {
+    mouse->press(button);
+  } else {
+    mouse->release(button);
+  }
+  return success_null();
+}
+
+FlMethodResponse* perform_mouse_scroll(FlValue* args) {
+  bool ok = true;
+  double dx = get_double_arg(args, "dx", &ok);
+  double dy = get_double_arg(args, "dy", &ok);
+  if (!ok) {
+    return bad_args("Missing or incorrect arguments for mouseScroll");
+  }
+
+  auto* mouse = get_mouse();
+  if (mouse == nullptr) {
+    return linux_mouse_error();
+  }
+
+  int vertical_distance = static_cast<int>(std::round(dy));
+  int horizontal_distance = static_cast<int>(std::round(dx));
+  if (vertical_distance != 0) {
+    mouse->vertical_scroll(vertical_distance);
+  }
+  if (horizontal_distance != 0) {
+    mouse->horizontal_scroll(horizontal_distance);
+  }
+  return success_null();
+}
+
+FlMethodResponse* get_monitor_count() {
+  XDisplay display;
+  if (display.get() == nullptr) {
+    return linux_display_error();
+  }
+  return success_int(static_cast<int>(get_monitors(display.get()).size()));
+}
+
+FlMethodResponse* clear_all_pressed_events() {
+  XDisplay display;
+  if (!display.supports_xtest()) {
+    return linux_display_error();
+  }
+
+  std::set<KeyCode> keys;
+  std::set<inputtino::Mouse::MOUSE_BUTTON> buttons;
+  {
+    std::lock_guard<std::mutex> lock(g_input_mutex);
+    keys.swap(g_pressed_keys);
+    buttons.swap(g_pressed_mouse_buttons);
+  }
+  for (KeyCode key : keys) {
+    XTestFakeKeyEvent(display.get(), key, False, CurrentTime);
+  }
+  auto* mouse = get_mouse();
+  if (mouse != nullptr) {
+    for (auto button : buttons) {
+      mouse->release(button);
+    }
+  }
+  XFlush(display.get());
+  return success_null();
+}
+
+}  // namespace
+
 // Called when a method call is received from Flutter.
 static void hardware_simulator_plugin_handle_method_call(
     HardwareSimulatorPlugin* self,
@@ -28,6 +497,39 @@ static void hardware_simulator_plugin_handle_method_call(
 
   if (strcmp(method, "getPlatformVersion") == 0) {
     response = get_platform_version();
+  } else if (strcmp(method, "getMonitorCount") == 0) {
+    response = get_monitor_count();
+  } else if (strcmp(method, "KeyPress") == 0) {
+    response = perform_key_event(fl_method_call_get_args(method_call));
+  } else if (strcmp(method, "mouseMoveR") == 0) {
+    response = perform_mouse_move_relative(fl_method_call_get_args(method_call));
+  } else if (strcmp(method, "mouseMoveA") == 0) {
+    response = perform_mouse_move_absolute(fl_method_call_get_args(method_call));
+  } else if (strcmp(method, "mousePress") == 0) {
+    response = perform_mouse_button(fl_method_call_get_args(method_call));
+  } else if (strcmp(method, "mouseScroll") == 0) {
+    response = perform_mouse_scroll(fl_method_call_get_args(method_call));
+  } else if (strcmp(method, "clearAllPressedEvents") == 0) {
+    response = clear_all_pressed_events();
+  } else if (strcmp(method, "lockCursor") == 0 ||
+             strcmp(method, "unlockCursor") == 0 ||
+             strcmp(method, "mouseMoveToWindowPosition") == 0) {
+    response = success_null();
+  } else if (strcmp(method, "isRunningAsSystem") == 0) {
+    response = success_bool(true);
+  } else if (strcmp(method, "setPrimaryDisplay") == 0) {
+    response = success_bool(false);
+  } else if (strcmp(method, "touchEvent") == 0 ||
+             strcmp(method, "touchMove") == 0 ||
+             strcmp(method, "penEvent") == 0 ||
+             strcmp(method, "penMove") == 0 ||
+             strcmp(method, "hookCursorImage") == 0 ||
+             strcmp(method, "unhookCursorImage") == 0 ||
+             strcmp(method, "hookCursorPosition") == 0 ||
+             strcmp(method, "unhookCursorPosition") == 0 ||
+             strcmp(method, "addDisplayCountChangedCallback") == 0 ||
+             strcmp(method, "removeDisplayCountChangedCallback") == 0) {
+    response = success_null();
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }

--- a/linux/udev/rules.d/60-cloudplayplus-hardware-simulator.rules
+++ b/linux/udev/rules.d/60-cloudplayplus-hardware-simulator.rules
@@ -1,0 +1,2 @@
+# Allows CloudPlayPlus hardware_simulator to create virtual input devices.
+KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", GROUP="input", MODE="0660", TAG+="uaccess"

--- a/scripts/setup_linux_input_permissions.sh
+++ b/scripts/setup_linux_input_permissions.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "This setup script is only needed on Linux."
+  exit 0
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="$(cd -- "$script_dir/.." && pwd)"
+rule_src="$plugin_root/linux/udev/rules.d/60-cloudplayplus-hardware-simulator.rules"
+rule_dst="/etc/udev/rules.d/60-cloudplayplus-hardware-simulator.rules"
+
+if [[ ! -f "$rule_src" ]]; then
+  echo "Missing udev rule: $rule_src" >&2
+  exit 1
+fi
+
+target_user="${SUDO_USER:-$USER}"
+if [[ -z "$target_user" || "$target_user" == "root" ]]; then
+  target_user="$(id -un)"
+fi
+
+echo "Installing CloudPlayPlus uinput udev rule..."
+sudo install -m 0644 "$rule_src" "$rule_dst"
+
+echo "Ensuring input group exists..."
+sudo groupadd -f input
+
+echo "Adding $target_user to input group..."
+sudo usermod -aG input "$target_user"
+
+echo "Loading uinput module..."
+sudo modprobe uinput || true
+
+echo "Reloading udev rules..."
+sudo udevadm control --reload-rules
+sudo udevadm trigger --property-match=DEVNAME=/dev/uinput || true
+
+echo
+echo "Current /dev/uinput state:"
+ls -l /dev/uinput || true
+
+echo
+echo "Done. Log out and back in so the new input group membership applies."
+echo "After logging back in, verify with:"
+echo "  id"
+echo "  ls -l /dev/uinput"


### PR DESCRIPTION
## Summary
- add inputtino as a Linux submodule dependency for uinput-backed virtual mouse events
- route Linux mouse move/click/scroll method-channel calls through a persistent inputtino mouse
- keep keyboard on the existing X11/XTest path and document Linux backend requirements

## Validation
- flutter build linux --debug (plugins/hardware_simulator/example)
- ./build/linux/x64/debug/plugins/hardware_simulator/hardware_simulator_test
- flutter test (plugins/hardware_simulator)
- flutter build linux --debug (main cloudplayplus app)

No UI change; release preview build not required.