### PR TITLE
feat(macos): runtime TCC permission self-check API

### DIFF
--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -3,6 +3,36 @@ export 'hardware_simulator_platform_interface.dart'
     show DisplayCountChangedCallback;
 import 'display_data.dart';
 
+/// Snapshot of the macOS TCC permissions relevant to remote-control hosting.
+class MacOSPermissionStatus {
+  /// Screen Recording — required to capture/stream the screen.
+  final bool screenCapture;
+
+  /// Post Event / Accessibility — required to inject synthetic mouse clicks
+  /// and key events. (Mouse *movement* via CGWarpMouseCursorPosition needs no
+  /// permission, so it is intentionally not tracked here.)
+  final bool inputInjection;
+
+  /// Legacy Accessibility (AXIsProcessTrusted), exposed for diagnostics.
+  final bool accessibility;
+
+  const MacOSPermissionStatus({
+    required this.screenCapture,
+    required this.inputInjection,
+    required this.accessibility,
+  });
+
+  /// True when every permission needed to host a session is granted.
+  bool get allGranted => screenCapture && inputInjection;
+
+  factory MacOSPermissionStatus.fromMap(Map<String, bool> m) =>
+      MacOSPermissionStatus(
+        screenCapture: m['screenCapture'] ?? false,
+        inputInjection: m['inputInjection'] ?? false,
+        accessibility: m['accessibility'] ?? false,
+      );
+}
+
 class HWKeyboard {
   HWKeyboard();
   void performKeyEvent(int keyCode, bool isDown) {
@@ -69,6 +99,26 @@ class HardwareSimulator {
 
   Future<String?> getPlatformVersion() {
     return HardwareSimulatorPlatform.instance.getPlatformVersion();
+  }
+
+  /// macOS only. Reads the current process's live TCC permission status.
+  /// Does not prompt — safe to poll for UI display.
+  static Future<MacOSPermissionStatus> checkMacOSPermissions() async {
+    final m = await HardwareSimulatorPlatform.instance.checkMacOSPermissions();
+    return MacOSPermissionStatus.fromMap(m);
+  }
+
+  /// macOS only. Triggers the consent prompt (or opens System Settings) for
+  /// [type]: `screenCapture` or `inputInjection`. Returns the granted state
+  /// after the request.
+  static Future<bool> requestMacOSPermission(String type) {
+    return HardwareSimulatorPlatform.instance.requestMacOSPermission(type);
+  }
+
+  /// macOS only. Opens a Privacy & Security pane in System Settings.
+  /// [section]: `screenCapture`, `accessibility`, or `inputMonitoring`.
+  static Future<void> openMacOSPrivacySettings(String section) {
+    return HardwareSimulatorPlatform.instance.openMacOSPrivacySettings(section);
   }
 
   //Only used for ios and android.

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -74,6 +74,28 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
     return version;
   }
 
+  @override
+  Future<Map<String, bool>> checkMacOSPermissions() async {
+    final res = await methodChannel.invokeMethod('checkMacOSPermissions');
+    if (res is Map) {
+      return res.map((k, v) => MapEntry(k.toString(), v == true));
+    }
+    return const <String, bool>{};
+  }
+
+  @override
+  Future<bool> requestMacOSPermission(String type) async {
+    final res = await methodChannel
+        .invokeMethod('requestMacOSPermission', {'type': type});
+    return res == true;
+  }
+
+  @override
+  Future<void> openMacOSPrivacySettings(String section) async {
+    await methodChannel
+        .invokeMethod('openMacOSPrivacySettings', {'section': section});
+  }
+
   Future<bool?> getIsMouseConnected() {
     return methodChannel.invokeMethod<bool>('isMouseConnected');
   }

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -42,6 +42,24 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
+  /// macOS only. Returns the current process's live TCC permission status as a
+  /// map with keys `screenCapture`, `inputInjection`, `accessibility`. Does not
+  /// prompt. On non-macOS platforms returns an empty map.
+  Future<Map<String, bool>> checkMacOSPermissions() async {
+    return const <String, bool>{};
+  }
+
+  /// macOS only. Asks macOS to show the consent prompt for [type]
+  /// (`screenCapture` or `inputInjection`), opening System Settings if no
+  /// auto-prompt is available. Returns the granted state after the request.
+  Future<bool> requestMacOSPermission(String type) async {
+    return false;
+  }
+
+  /// macOS only. Opens the given Privacy & Security pane in System Settings.
+  /// [section] is one of `screenCapture`, `accessibility`, `inputMonitoring`.
+  Future<void> openMacOSPrivacySettings(String section) async {}
+
   Future<bool?> getIsMouseConnected() {
     throw UnimplementedError('getIsMouseConnected() has not been implemented.');
   }

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1,6 +1,8 @@
 import Cocoa
-import FlutterMacOS 
+import FlutterMacOS
 import CommonCrypto
+import CoreGraphics
+import ApplicationServices
 
 class CursorConstants {    
   static let cursorVisible = 2
@@ -772,10 +774,100 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   
   var activities: [String: NSObjectProtocol] = [:]
 
+  // MARK: - macOS permission self-check
+
+  /// Whether this process can capture the screen. Uses the official preflight
+  /// API on macOS 11+; falls back to a window-name heuristic on 10.15 (where
+  /// no preflight API exists — if we can read another app's window title, the
+  /// Screen Recording grant is in effect).
+  ///
+  /// NOTE: `CGPreflightScreenCaptureAccess()` caches its result for the whole
+  /// process lifetime, so a freshly-granted permission only shows up after the
+  /// app is relaunched. The UI tells the user this after they request access.
+  private func macScreenCaptureGranted() -> Bool {
+    if #available(macOS 11.0, *) {
+      return CGPreflightScreenCaptureAccess()
+    }
+    let myPid = NSRunningApplication.current.processIdentifier
+    let info = CGWindowListCopyWindowInfo(
+      [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+    ) as? [[String: Any]] ?? []
+    for w in info {
+      guard let pid = w[kCGWindowOwnerPID as String] as? pid_t, pid != myPid else { continue }
+      if let name = w[kCGWindowName as String] as? String, !name.isEmpty {
+        return true
+      }
+    }
+    return false
+  }
+
+  /// Whether this process may inject synthetic input (mouse clicks, key events)
+  /// via CGEventPost. macOS exposes a dedicated "Post Event" privilege; being
+  /// AX-trusted also satisfies it, so accept either.
+  ///
+  /// NOTE: both calls cache in-process, so a freshly-granted permission only
+  /// shows up after relaunch. The UI tells the user this after they request it.
+  private func macInputInjectionGranted() -> Bool {
+    return CGPreflightPostEventAccess() || AXIsProcessTrusted()
+  }
+
+  /// Opens the relevant pane of System Settings → Privacy & Security.
+  private func openMacOSPrivacySettings(section: String) {
+    let anchor: String
+    switch section {
+    case "screenCapture": anchor = "Privacy_ScreenCapture"
+    case "accessibility": anchor = "Privacy_Accessibility"
+    case "inputMonitoring": anchor = "Privacy_ListenEvent"
+    default: anchor = "Privacy"
+    }
+    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(anchor)") {
+      NSWorkspace.shared.open(url)
+    }
+  }
+
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "getPlatformVersion":
       result("macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
+    case "checkMacOSPermissions":
+      // Reports the *current process's* live TCC status. Does NOT prompt.
+      // - screenCapture: needed to grab the screen (ScreenCaptureKit / CGDisplayStream)
+      // - inputInjection: needed to post synthetic mouse clicks / key events (CGEventPost)
+      // - accessibility: legacy AX trust, kept for diagnostics
+      result([
+        "screenCapture": macScreenCaptureGranted(),
+        "inputInjection": macInputInjectionGranted(),
+        "accessibility": AXIsProcessTrusted(),
+      ])
+    case "requestMacOSPermission":
+      // Actively asks macOS to show the consent prompt for the given permission.
+      // For permissions that have no auto-prompt API on this OS, opens the
+      // relevant System Settings pane instead. Returns the (possibly updated)
+      // granted state after the request.
+      let type = (call.arguments as? [String: Any])?["type"] as? String ?? ""
+      switch type {
+      case "screenCapture":
+        if #available(macOS 11.0, *) {
+          // Triggers the system prompt the first time; afterwards a no-op.
+          let granted = CGRequestScreenCaptureAccess()
+          if !granted { openMacOSPrivacySettings(section: "screenCapture") }
+          result(granted)
+        } else {
+          openMacOSPrivacySettings(section: "screenCapture")
+          result(macScreenCaptureGranted())
+        }
+      case "inputInjection":
+        // CGRequestPostEventAccess shows the prompt the first time (macOS 10.15+).
+        let granted = CGRequestPostEventAccess()
+        if !granted { openMacOSPrivacySettings(section: "accessibility") }
+        result(granted)
+      default:
+        result(FlutterError(code: "BAD_ARGS", message: "Unknown permission type: \(type)", details: nil))
+      }
+    case "openMacOSPrivacySettings":
+      let section = (call.arguments as? [String: Any])?["section"] as? String ?? ""
+      openMacOSPrivacySettings(section: section)
+      result(nil)
     case "beginActivity":
       let key = UUID().uuidString
       let reason = call.arguments as? String ?? "Prevent nap to do an important task."


### PR DESCRIPTION
## What

Adds a macOS-only API so the host app can detect and request the TCC permissions a remote-control host needs.

New method-channel calls (also surfaced through the Dart `HardwareSimulator` API + `MacOSPermissionStatus` model):

- **`checkMacOSPermissions`** — non-prompting read of:
  - `screenCapture` (`CGPreflightScreenCaptureAccess`, window-name heuristic on 10.15)
  - `inputInjection` (`CGPreflightPostEventAccess` / `AXIsProcessTrusted`)
  - `accessibility` (diagnostics)
- **`requestMacOSPermission(type)`** — triggers the consent prompt (`CGRequestScreenCaptureAccess` / `CGRequestPostEventAccess`); opens System Settings if no prompt is available.
- **`openMacOSPrivacySettings(section)`** — jumps to a Privacy & Security pane.

## Why

After a rebuild the host could silently lose screen-recording / click-injection permission. The app needs to detect this at runtime and guide the user to re-grant.

## Notes

- Mouse **movement** (`CGWarpMouseCursorPosition`) needs no permission, so it is intentionally not tracked.
- `CGPreflight*` results are cached per-process, so a freshly-granted permission only reflects after relaunch — the consuming UI tells the user this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)