### PR TITLE
fix(windows): route input through desktop service

### DIFF
--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -134,6 +134,11 @@ class HardwareSimulator {
     return HardwareSimulatorPlatform.instance.registerService();
   }
 
+  static Future<void> setDesktopServiceAvailable(bool available) {
+    return HardwareSimulatorPlatform.instance
+        .setDesktopServiceAvailable(available);
+  }
+
   static Future<void> unregisterService() {
     return HardwareSimulatorPlatform.instance.unregisterService();
   }

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -130,6 +130,16 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   }
 
   @override
+  Future<void> setDesktopServiceAvailable(bool available) async {
+    if (!Platform.isWindows) {
+      return;
+    }
+    await methodChannel.invokeMethod('setDesktopServiceAvailable', {
+      'available': available,
+    });
+  }
+
+  @override
   Future<void> unregisterService() async {
     if (!Platform.isWindows) {
       return;

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -73,6 +73,10 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     return false;
   }
 
+  Future<void> setDesktopServiceAvailable(bool available) async {
+    return;
+  }
+
   Future<void> unregisterService() async {
     return;
   }

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -18,6 +18,8 @@ set(PLUGIN_NAME "hardware_simulator_plugin")
 
 # Any new source files that you add to the plugin should be added here.
 list(APPEND PLUGIN_SOURCES
+  "desktop_service_input_client.cpp"
+  "desktop_service_input_client.h"
   "hardware_simulator_plugin.cpp"
   "hardware_simulator_plugin.h"
   "cursor_monitor.cc"
@@ -94,4 +96,3 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   # Link necessary libraries for the example
   target_link_libraries(virtual_display_example PRIVATE)
 endif()
-

--- a/windows/desktop_service_input_client.cpp
+++ b/windows/desktop_service_input_client.cpp
@@ -51,9 +51,15 @@ DesktopServiceInputClient::~DesktopServiceInputClient() {
   Close();
 }
 
+void DesktopServiceInputClient::Prime() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  RequestProbeLocked();
+}
+
 bool DesktopServiceInputClient::SendInputMessage(const INPUT& input) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (!EnsureConnectedLocked()) {
+  if (pipe_ == INVALID_HANDLE_VALUE) {
+    RequestProbeLocked();
     return false;
   }
 
@@ -68,57 +74,143 @@ bool DesktopServiceInputClient::SendInputMessage(const INPUT& input) {
 }
 
 void DesktopServiceInputClient::Close() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  CloseLocked();
+  std::thread probe_thread;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ClosePipeLocked();
+    stop_requested_ = true;
+    probe_requested_ = false;
+    probe_cv_.notify_all();
+    if (probe_thread_.joinable()) {
+      probe_thread = std::move(probe_thread_);
+    }
+  }
+
+  if (probe_thread.joinable()) {
+    probe_thread.join();
+  }
 }
 
-bool DesktopServiceInputClient::EnsureConnectedLocked() {
-  if (pipe_ != INVALID_HANDLE_VALUE) {
+bool DesktopServiceInputClient::EnsureProbeThreadLocked() {
+  if (probe_thread_.joinable()) {
     return true;
+  }
+
+  stop_requested_ = false;
+  try {
+    probe_thread_ = std::thread(&DesktopServiceInputClient::ProbeLoop, this);
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+void DesktopServiceInputClient::RequestProbeLocked() {
+  if (pipe_ != INVALID_HANDLE_VALUE ||
+      probe_requested_ ||
+      probe_in_flight_ ||
+      !EnsureProbeThreadLocked()) {
+    return;
   }
 
   const auto now = std::chrono::steady_clock::now();
   if (now < next_probe_time_) {
-    return false;
+    return;
   }
-  next_probe_time_ = now + kProbeCooldown;
 
-  pipe_ = CreateFileW(kInputPipeName, GENERIC_READ | GENERIC_WRITE, 0, nullptr,
-                      OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
-  if (pipe_ == INVALID_HANDLE_VALUE) {
+  state_ = ServiceState::kProbing;
+  probe_requested_ = true;
+  probe_cv_.notify_one();
+}
+
+void DesktopServiceInputClient::ProbeLoop() {
+  for (;;) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!probe_requested_ && pipe_ == INVALID_HANDLE_VALUE &&
+        next_probe_time_ != std::chrono::steady_clock::time_point{}) {
+      probe_cv_.wait_until(lock, next_probe_time_, [this] {
+        return stop_requested_ || probe_requested_;
+      });
+    } else {
+      probe_cv_.wait(lock, [this] {
+        return stop_requested_ || probe_requested_;
+      });
+    }
+
+    if (stop_requested_) {
+      break;
+    }
+
+    probe_requested_ = false;
+    if (pipe_ != INVALID_HANDLE_VALUE) {
+      state_ = ServiceState::kConnected;
+      continue;
+    }
+
+    state_ = ServiceState::kProbing;
+    probe_in_flight_ = true;
+    lock.unlock();
+
+    HANDLE pipe = TryConnect();
+
+    lock.lock();
+    probe_in_flight_ = false;
+
+    if (stop_requested_) {
+      if (pipe != INVALID_HANDLE_VALUE) {
+        CloseHandle(pipe);
+      }
+      break;
+    }
+
+    if (pipe != INVALID_HANDLE_VALUE) {
+      if (pipe_ == INVALID_HANDLE_VALUE) {
+        pipe_ = pipe;
+        state_ = ServiceState::kConnected;
+        next_probe_time_ = {};
+      } else {
+        CloseHandle(pipe);
+      }
+    } else {
+      state_ = ServiceState::kDisconnected;
+      next_probe_time_ = std::chrono::steady_clock::now() + kProbeCooldown;
+    }
+  }
+}
+
+HANDLE DesktopServiceInputClient::TryConnect() {
+  HANDLE pipe = CreateFileW(kInputPipeName, GENERIC_READ | GENERIC_WRITE, 0,
+                            nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED,
+                            nullptr);
+  if (pipe == INVALID_HANDLE_VALUE) {
     const DWORD err = GetLastError();
     if (err == ERROR_PIPE_BUSY &&
         WaitNamedPipeW(kInputPipeName, kConnectBusyWaitMs)) {
-      pipe_ = CreateFileW(kInputPipeName, GENERIC_READ | GENERIC_WRITE, 0,
-                          nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED,
-                          nullptr);
+      pipe = CreateFileW(kInputPipeName, GENERIC_READ | GENERIC_WRITE, 0,
+                         nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED,
+                         nullptr);
     }
   }
 
-  if (pipe_ == INVALID_HANDLE_VALUE) {
-    return false;
+  if (pipe == INVALID_HANDLE_VALUE) {
+    return INVALID_HANDLE_VALUE;
   }
 
   DWORD mode = PIPE_READMODE_MESSAGE;
-  if (!SetNamedPipeHandleState(pipe_, &mode, nullptr, nullptr)) {
-    CloseLocked();
-    return false;
+  if (!SetNamedPipeHandleState(pipe, &mode, nullptr, nullptr)) {
+    CloseHandle(pipe);
+    return INVALID_HANDLE_VALUE;
   }
 
-  stop_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-  if (!stop_event_) {
-    CloseLocked();
-    return false;
-  }
-
-  return true;
+  return pipe;
 }
 
 bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
   OVERLAPPED overlapped = {};
   overlapped.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
   if (!overlapped.hEvent) {
-    CloseLocked();
+    ClosePipeLocked();
+    RequestProbeLocked();
     return false;
   }
 
@@ -127,26 +219,27 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
   if (!ok) {
     const DWORD err = GetLastError();
     if (err == ERROR_IO_PENDING) {
-      HANDLE wait_handles[] = {overlapped.hEvent, stop_event_};
-      DWORD wait = WaitForMultipleObjects(2, wait_handles, FALSE,
-                                          kWriteTimeoutMs);
+      DWORD wait = WaitForSingleObject(overlapped.hEvent, kWriteTimeoutMs);
       if (wait != WAIT_OBJECT_0 ||
           !GetOverlappedResult(pipe_, &overlapped, &written, FALSE)) {
         CancelIo(pipe_);
         CloseHandle(overlapped.hEvent);
-        CloseLocked();
+        ClosePipeLocked();
+        RequestProbeLocked();
         return false;
       }
     } else {
       CloseHandle(overlapped.hEvent);
-      CloseLocked();
+      ClosePipeLocked();
+      RequestProbeLocked();
       return false;
     }
   }
 
   CloseHandle(overlapped.hEvent);
   if (written != size) {
-    CloseLocked();
+    ClosePipeLocked();
+    RequestProbeLocked();
     return false;
   }
   return true;
@@ -189,15 +282,13 @@ bool DesktopServiceInputClient::SendMouseLocked(const MOUSEINPUT& input) {
   return SendRawLocked(buffer, sizeof(buffer));
 }
 
-void DesktopServiceInputClient::CloseLocked() {
-  if (stop_event_) {
-    SetEvent(stop_event_);
-    CloseHandle(stop_event_);
-    stop_event_ = nullptr;
-  }
+void DesktopServiceInputClient::ClosePipeLocked() {
   if (pipe_ != INVALID_HANDLE_VALUE) {
     CloseHandle(pipe_);
     pipe_ = INVALID_HANDLE_VALUE;
+  }
+  if (state_ == ServiceState::kConnected) {
+    state_ = ServiceState::kDisconnected;
   }
 }
 

--- a/windows/desktop_service_input_client.cpp
+++ b/windows/desktop_service_input_client.cpp
@@ -1,0 +1,204 @@
+#include "desktop_service_input_client.h"
+
+#include <cstring>
+
+namespace hardware_simulator {
+namespace {
+
+constexpr const wchar_t* kInputPipeName =
+    L"\\\\.\\pipe\\cloudplayplus_desktop_input";
+constexpr uint32_t kMsgKeyInput = 0x02;
+constexpr uint32_t kMsgMouseInput = 0x03;
+constexpr DWORD kConnectBusyWaitMs = 2;
+constexpr DWORD kWriteTimeoutMs = 20;
+constexpr auto kProbeCooldown = std::chrono::milliseconds(500);
+
+#pragma pack(push, 1)
+struct MsgHeader {
+  uint32_t type;
+  uint32_t payload_size;
+  uint32_t seq;
+};
+
+struct KeyboardInputPayload {
+  uint16_t vk;
+  uint16_t scan_code;
+  uint32_t flags;
+};
+
+struct MouseInputPayload {
+  int32_t dx;
+  int32_t dy;
+  uint32_t flags;
+  int32_t data;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(MsgHeader) == 12, "MsgHeader size must match service IPC");
+static_assert(sizeof(KeyboardInputPayload) == 8,
+              "KeyboardInput size must match service IPC");
+static_assert(sizeof(MouseInputPayload) == 16,
+              "MouseInput size must match service IPC");
+
+}  // namespace
+
+DesktopServiceInputClient& DesktopServiceInputClient::Instance() {
+  static DesktopServiceInputClient client;
+  return client;
+}
+
+DesktopServiceInputClient::~DesktopServiceInputClient() {
+  Close();
+}
+
+bool DesktopServiceInputClient::SendInputMessage(const INPUT& input) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!EnsureConnectedLocked()) {
+    return false;
+  }
+
+  switch (input.type) {
+    case INPUT_KEYBOARD:
+      return SendKeyboardLocked(input.ki);
+    case INPUT_MOUSE:
+      return SendMouseLocked(input.mi);
+    default:
+      return false;
+  }
+}
+
+void DesktopServiceInputClient::Close() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  CloseLocked();
+}
+
+bool DesktopServiceInputClient::EnsureConnectedLocked() {
+  if (pipe_ != INVALID_HANDLE_VALUE) {
+    return true;
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  if (now < next_probe_time_) {
+    return false;
+  }
+  next_probe_time_ = now + kProbeCooldown;
+
+  pipe_ = CreateFileW(kInputPipeName, GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                      OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
+  if (pipe_ == INVALID_HANDLE_VALUE) {
+    const DWORD err = GetLastError();
+    if (err == ERROR_PIPE_BUSY &&
+        WaitNamedPipeW(kInputPipeName, kConnectBusyWaitMs)) {
+      pipe_ = CreateFileW(kInputPipeName, GENERIC_READ | GENERIC_WRITE, 0,
+                          nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED,
+                          nullptr);
+    }
+  }
+
+  if (pipe_ == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  DWORD mode = PIPE_READMODE_MESSAGE;
+  if (!SetNamedPipeHandleState(pipe_, &mode, nullptr, nullptr)) {
+    CloseLocked();
+    return false;
+  }
+
+  stop_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (!stop_event_) {
+    CloseLocked();
+    return false;
+  }
+
+  return true;
+}
+
+bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
+  OVERLAPPED overlapped = {};
+  overlapped.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (!overlapped.hEvent) {
+    CloseLocked();
+    return false;
+  }
+
+  DWORD written = 0;
+  BOOL ok = WriteFile(pipe_, data, size, &written, &overlapped);
+  if (!ok) {
+    const DWORD err = GetLastError();
+    if (err == ERROR_IO_PENDING) {
+      HANDLE wait_handles[] = {overlapped.hEvent, stop_event_};
+      DWORD wait = WaitForMultipleObjects(2, wait_handles, FALSE,
+                                          kWriteTimeoutMs);
+      if (wait != WAIT_OBJECT_0 ||
+          !GetOverlappedResult(pipe_, &overlapped, &written, FALSE)) {
+        CancelIo(pipe_);
+        CloseHandle(overlapped.hEvent);
+        CloseLocked();
+        return false;
+      }
+    } else {
+      CloseHandle(overlapped.hEvent);
+      CloseLocked();
+      return false;
+    }
+  }
+
+  CloseHandle(overlapped.hEvent);
+  if (written != size) {
+    CloseLocked();
+    return false;
+  }
+  return true;
+}
+
+bool DesktopServiceInputClient::SendKeyboardLocked(const KEYBDINPUT& input) {
+  uint8_t buffer[sizeof(MsgHeader) + sizeof(KeyboardInputPayload)] = {};
+
+  MsgHeader header = {};
+  header.type = kMsgKeyInput;
+  header.payload_size = sizeof(KeyboardInputPayload);
+  header.seq = 0;
+
+  KeyboardInputPayload payload = {};
+  payload.vk = input.wVk;
+  payload.scan_code = input.wScan;
+  payload.flags = input.dwFlags;
+
+  memcpy(buffer, &header, sizeof(header));
+  memcpy(buffer + sizeof(header), &payload, sizeof(payload));
+  return SendRawLocked(buffer, sizeof(buffer));
+}
+
+bool DesktopServiceInputClient::SendMouseLocked(const MOUSEINPUT& input) {
+  uint8_t buffer[sizeof(MsgHeader) + sizeof(MouseInputPayload)] = {};
+
+  MsgHeader header = {};
+  header.type = kMsgMouseInput;
+  header.payload_size = sizeof(MouseInputPayload);
+  header.seq = 0;
+
+  MouseInputPayload payload = {};
+  payload.dx = input.dx;
+  payload.dy = input.dy;
+  payload.flags = input.dwFlags;
+  payload.data = static_cast<int32_t>(input.mouseData);
+
+  memcpy(buffer, &header, sizeof(header));
+  memcpy(buffer + sizeof(header), &payload, sizeof(payload));
+  return SendRawLocked(buffer, sizeof(buffer));
+}
+
+void DesktopServiceInputClient::CloseLocked() {
+  if (stop_event_) {
+    SetEvent(stop_event_);
+    CloseHandle(stop_event_);
+    stop_event_ = nullptr;
+  }
+  if (pipe_ != INVALID_HANDLE_VALUE) {
+    CloseHandle(pipe_);
+    pipe_ = INVALID_HANDLE_VALUE;
+  }
+}
+
+}  // namespace hardware_simulator

--- a/windows/desktop_service_input_client.cpp
+++ b/windows/desktop_service_input_client.cpp
@@ -11,7 +11,6 @@ constexpr uint32_t kMsgKeyInput = 0x02;
 constexpr uint32_t kMsgMouseInput = 0x03;
 constexpr DWORD kConnectBusyWaitMs = 2;
 constexpr DWORD kWriteTimeoutMs = 20;
-constexpr auto kProbeCooldown = std::chrono::milliseconds(500);
 
 #pragma pack(push, 1)
 struct MsgHeader {
@@ -51,15 +50,20 @@ DesktopServiceInputClient::~DesktopServiceInputClient() {
   Close();
 }
 
-void DesktopServiceInputClient::Prime() {
+void DesktopServiceInputClient::SetServiceAvailable(bool available) {
   std::lock_guard<std::mutex> lock(mutex_);
+  service_available_ = available;
+  if (!service_available_) {
+    ClosePipeLocked();
+    probe_requested_ = false;
+    return;
+  }
   RequestProbeLocked();
 }
 
 bool DesktopServiceInputClient::SendInputMessage(const INPUT& input) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (pipe_ == INVALID_HANDLE_VALUE) {
-    RequestProbeLocked();
     return false;
   }
 
@@ -107,14 +111,10 @@ bool DesktopServiceInputClient::EnsureProbeThreadLocked() {
 
 void DesktopServiceInputClient::RequestProbeLocked() {
   if (pipe_ != INVALID_HANDLE_VALUE ||
+      !service_available_ ||
       probe_requested_ ||
       probe_in_flight_ ||
       !EnsureProbeThreadLocked()) {
-    return;
-  }
-
-  const auto now = std::chrono::steady_clock::now();
-  if (now < next_probe_time_) {
     return;
   }
 
@@ -126,16 +126,9 @@ void DesktopServiceInputClient::RequestProbeLocked() {
 void DesktopServiceInputClient::ProbeLoop() {
   for (;;) {
     std::unique_lock<std::mutex> lock(mutex_);
-    if (!probe_requested_ && pipe_ == INVALID_HANDLE_VALUE &&
-        next_probe_time_ != std::chrono::steady_clock::time_point{}) {
-      probe_cv_.wait_until(lock, next_probe_time_, [this] {
-        return stop_requested_ || probe_requested_;
-      });
-    } else {
-      probe_cv_.wait(lock, [this] {
-        return stop_requested_ || probe_requested_;
-      });
-    }
+    probe_cv_.wait(lock, [this] {
+      return stop_requested_ || probe_requested_;
+    });
 
     if (stop_requested_) {
       break;
@@ -163,17 +156,20 @@ void DesktopServiceInputClient::ProbeLoop() {
       break;
     }
 
-    if (pipe != INVALID_HANDLE_VALUE) {
+    if (!service_available_) {
+      if (pipe != INVALID_HANDLE_VALUE) {
+        CloseHandle(pipe);
+      }
+      state_ = ServiceState::kDisconnected;
+    } else if (pipe != INVALID_HANDLE_VALUE) {
       if (pipe_ == INVALID_HANDLE_VALUE) {
         pipe_ = pipe;
         state_ = ServiceState::kConnected;
-        next_probe_time_ = {};
       } else {
         CloseHandle(pipe);
       }
     } else {
       state_ = ServiceState::kDisconnected;
-      next_probe_time_ = std::chrono::steady_clock::now() + kProbeCooldown;
     }
   }
 }
@@ -210,7 +206,6 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
   overlapped.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
   if (!overlapped.hEvent) {
     ClosePipeLocked();
-    RequestProbeLocked();
     return false;
   }
 
@@ -225,13 +220,11 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
         CancelIo(pipe_);
         CloseHandle(overlapped.hEvent);
         ClosePipeLocked();
-        RequestProbeLocked();
         return false;
       }
     } else {
       CloseHandle(overlapped.hEvent);
       ClosePipeLocked();
-      RequestProbeLocked();
       return false;
     }
   }
@@ -239,7 +232,6 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
   CloseHandle(overlapped.hEvent);
   if (written != size) {
     ClosePipeLocked();
-    RequestProbeLocked();
     return false;
   }
   return true;

--- a/windows/desktop_service_input_client.cpp
+++ b/windows/desktop_service_input_client.cpp
@@ -206,6 +206,7 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
   overlapped.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
   if (!overlapped.hEvent) {
     ClosePipeLocked();
+    RequestProbeLocked();
     return false;
   }
 
@@ -220,11 +221,13 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
         CancelIo(pipe_);
         CloseHandle(overlapped.hEvent);
         ClosePipeLocked();
+        RequestProbeLocked();
         return false;
       }
     } else {
       CloseHandle(overlapped.hEvent);
       ClosePipeLocked();
+      RequestProbeLocked();
       return false;
     }
   }
@@ -232,6 +235,7 @@ bool DesktopServiceInputClient::SendRawLocked(const void* data, uint32_t size) {
   CloseHandle(overlapped.hEvent);
   if (written != size) {
     ClosePipeLocked();
+    RequestProbeLocked();
     return false;
   }
   return true;

--- a/windows/desktop_service_input_client.h
+++ b/windows/desktop_service_input_client.h
@@ -1,0 +1,40 @@
+#ifndef HARDWARE_SIMULATOR_DESKTOP_SERVICE_INPUT_CLIENT_H_
+#define HARDWARE_SIMULATOR_DESKTOP_SERVICE_INPUT_CLIENT_H_
+
+#include <windows.h>
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+
+namespace hardware_simulator {
+
+class DesktopServiceInputClient {
+ public:
+  static DesktopServiceInputClient& Instance();
+
+  bool SendInputMessage(const INPUT& input);
+  void Close();
+
+ private:
+  DesktopServiceInputClient() = default;
+  ~DesktopServiceInputClient();
+
+  DesktopServiceInputClient(const DesktopServiceInputClient&) = delete;
+  DesktopServiceInputClient& operator=(const DesktopServiceInputClient&) = delete;
+
+  bool EnsureConnectedLocked();
+  bool SendRawLocked(const void* data, uint32_t size);
+  bool SendKeyboardLocked(const KEYBDINPUT& input);
+  bool SendMouseLocked(const MOUSEINPUT& input);
+  void CloseLocked();
+
+  std::mutex mutex_;
+  HANDLE pipe_ = INVALID_HANDLE_VALUE;
+  HANDLE stop_event_ = nullptr;
+  std::chrono::steady_clock::time_point next_probe_time_{};
+};
+
+}  // namespace hardware_simulator
+
+#endif  // HARDWARE_SIMULATOR_DESKTOP_SERVICE_INPUT_CLIENT_H_

--- a/windows/desktop_service_input_client.h
+++ b/windows/desktop_service_input_client.h
@@ -4,8 +4,10 @@
 #include <windows.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <thread>
 
 namespace hardware_simulator {
 
@@ -13,25 +15,40 @@ class DesktopServiceInputClient {
  public:
   static DesktopServiceInputClient& Instance();
 
+  void Prime();
   bool SendInputMessage(const INPUT& input);
   void Close();
 
  private:
+  enum class ServiceState {
+    kDisconnected,
+    kProbing,
+    kConnected,
+  };
+
   DesktopServiceInputClient() = default;
   ~DesktopServiceInputClient();
 
   DesktopServiceInputClient(const DesktopServiceInputClient&) = delete;
   DesktopServiceInputClient& operator=(const DesktopServiceInputClient&) = delete;
 
-  bool EnsureConnectedLocked();
+  bool EnsureProbeThreadLocked();
+  void RequestProbeLocked();
+  void ProbeLoop();
+  HANDLE TryConnect();
   bool SendRawLocked(const void* data, uint32_t size);
   bool SendKeyboardLocked(const KEYBDINPUT& input);
   bool SendMouseLocked(const MOUSEINPUT& input);
-  void CloseLocked();
+  void ClosePipeLocked();
 
   std::mutex mutex_;
+  std::condition_variable probe_cv_;
+  std::thread probe_thread_;
   HANDLE pipe_ = INVALID_HANDLE_VALUE;
-  HANDLE stop_event_ = nullptr;
+  ServiceState state_ = ServiceState::kDisconnected;
+  bool stop_requested_ = false;
+  bool probe_requested_ = false;
+  bool probe_in_flight_ = false;
   std::chrono::steady_clock::time_point next_probe_time_{};
 };
 

--- a/windows/desktop_service_input_client.h
+++ b/windows/desktop_service_input_client.h
@@ -3,7 +3,6 @@
 
 #include <windows.h>
 
-#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
@@ -15,7 +14,7 @@ class DesktopServiceInputClient {
  public:
   static DesktopServiceInputClient& Instance();
 
-  void Prime();
+  void SetServiceAvailable(bool available);
   bool SendInputMessage(const INPUT& input);
   void Close();
 
@@ -49,7 +48,7 @@ class DesktopServiceInputClient {
   bool stop_requested_ = false;
   bool probe_requested_ = false;
   bool probe_in_flight_ = false;
-  std::chrono::steady_clock::time_point next_probe_time_{};
+  bool service_available_ = false;
 };
 
 }  // namespace hardware_simulator

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -851,6 +851,8 @@ void HardwareSimulatorPlugin::RegisterWithRegistrar(
       plugin_pointer->StartMonitorThread();
   }
 
+  DesktopServiceInputClient::Instance().Prime();
+
   registrar->AddPlugin(std::move(plugin));
 
   // start to monitor display resolution and DPI.
@@ -875,6 +877,7 @@ HardwareSimulatorPlugin::HardwareSimulatorPlugin() {
 }
 
 HardwareSimulatorPlugin::~HardwareSimulatorPlugin() {
+    DesktopServiceInputClient::Instance().Close();
     StopMonitorThread();
     destroyTouchDevice();
     destroyPenDevice();

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -1,6 +1,7 @@
 #include "hardware_simulator_plugin.h"
 
 #include "cursor_monitor.h"
+#include "desktop_service_input_client.h"
 #include "gamecontroller_manager.h"
 #include "notification_window.h"
 #include "virtual_display_control.h"
@@ -902,6 +903,10 @@ void async_send_input_retry(INPUT& i) {
 }
 
 void send_input(INPUT& i) {
+    if (DesktopServiceInputClient::Instance().SendInputMessage(i)) {
+        return;
+    }
+
     auto send = SendInput(1, &i, sizeof(INPUT));
     if (send != 1) {
         // put resend into new thread.

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -851,8 +851,6 @@ void HardwareSimulatorPlugin::RegisterWithRegistrar(
       plugin_pointer->StartMonitorThread();
   }
 
-  DesktopServiceInputClient::Instance().Prime();
-
   registrar->AddPlugin(std::move(plugin));
 
   // start to monitor display resolution and DPI.
@@ -1215,6 +1213,17 @@ void HardwareSimulatorPlugin::HandleMethodCall(
       version_stream << "7";
     }
     result->Success(flutter::EncodableValue(version_stream.str()));
+  } else if (method_call.method_name().compare("setDesktopServiceAvailable") == 0) {
+    bool available = false;
+    if (args) {
+      auto available_iter = args->find(flutter::EncodableValue("available"));
+      if (available_iter != args->end() &&
+          std::holds_alternative<bool>(available_iter->second)) {
+        available = std::get<bool>(available_iter->second);
+      }
+    }
+    DesktopServiceInputClient::Instance().SetServiceAvailable(available);
+    result->Success(nullptr);
   } else if (method_call.method_name().compare("getMonitorCount") == 0) {
     int monitorCount = GetSystemMetrics(SM_CMONITORS);
     //update_monitors();


### PR DESCRIPTION
## Summary
- Add a small Windows named-pipe client for the desktop service input pipe.
- Route keyboard and mouse SendInput calls through the service when available.
- Keep the existing in-process SendInput retry path as a fallback for old/no service installs.

## Validation
- git diff --check
- Built hardware_simulator_plugin Release target through the main Windows CMake tree.
- Full flutter build windows --release reached CMake install and failed while build\windows\x64\runner\Release\cloudplayplus.exe was running locally; plugin target itself compiled successfully.

Depends on CloudPlayPlus/CloudPlayPlusService#6 for the new input pipe at runtime. The fallback path keeps this safe with older service binaries.