### PR TITLE
fix(cursor): use endian-stable position payloads

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -157,16 +157,16 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
         // 获取显示器ID和鼠标位置信息
         int screenId = messageInfo;
 
-        // 检查是否有位置数据（新版本有8字节，旧版本可能为空）
-        if (cursorImage.isNotEmpty && cursorImage.length >= 8) {
+        // 位置数据为 4 字节：x/y 各一个 u16 normalized little-endian。
+        if (cursorImage.isNotEmpty && cursorImage.length >= 4) {
           ByteData byteData = ByteData.sublistView(cursorImage);
-          double xPercent = byteData.getFloat32(0, Endian.little);
-          double yPercent = byteData.getFloat32(4, Endian.little);
+          double xPercent = byteData.getUint16(0, Endian.little) / 65535.0;
+          double yPercent = byteData.getUint16(2, Endian.little) / 65535.0;
 
           print(
               'Cursor became visible - Screen ID: $screenId, X: ${(xPercent * 100).toStringAsFixed(1)}%, Y: ${(yPercent * 100).toStringAsFixed(1)}%');
         } else {
-          // 兼容旧版本，没有位置数据
+          // 没有位置数据
           print(
               'Cursor became visible - Screen ID: $screenId (no position data)');
         }

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -598,11 +598,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     guard let position = currentMousePosition() else {
       return
     }
-    var positionBytes = Data()
-    var x = Float(position.xPercent)
-    var y = Float(position.yPercent)
-    withUnsafeBytes(of: &x) { positionBytes.append(contentsOf: $0) }
-    withUnsafeBytes(of: &y) { positionBytes.append(contentsOf: $0) }
+    let positionBytes = cursorPositionPayload(position.xPercent, position.yPercent)
 
     methodChannel?.invokeMethod("onCursorImageMessage", arguments: [
       "callbackID": callbackID,
@@ -610,6 +606,28 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       "msg_info": position.screenId,
       "cursorImage": FlutterStandardTypedData.init(bytes: positionBytes)
     ])
+  }
+
+  private func cursorPositionPayload(_ xPercent: Double, _ yPercent: Double) -> Data {
+    var bytes = Data()
+    appendUInt16LE(encodeUnitU16(xPercent), to: &bytes)
+    appendUInt16LE(encodeUnitU16(yPercent), to: &bytes)
+    return bytes
+  }
+
+  private func encodeUnitU16(_ value: Double) -> UInt16 {
+    if !value.isFinite || value <= 0.0 {
+      return 0
+    }
+    if value >= 1.0 {
+      return UInt16.max
+    }
+    return UInt16((value * 65535.0).rounded())
+  }
+
+  private func appendUInt16LE(_ value: UInt16, to data: inout Data) {
+    var littleEndian = value.littleEndian
+    withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
   }
 
   private func sendCursorPositionToAll(message: Int = CursorConstants.cursorPositionChanged) {

--- a/windows/cursor_monitor.cc
+++ b/windows/cursor_monitor.cc
@@ -515,40 +515,26 @@ LRESULT CALLBACK MousePositionHookProc(int nCode, WPARAM wParam, LPARAM lParam) 
     return CallNextHookEx(positionHook, nCode, wParam, lParam);
 }
 
-std::vector<uint8_t> FloatToBytes(float x, float y) {
+uint16_t EncodeUnitU16(float value) {
+    if (value != value || value <= 0.0f) {
+        return 0;
+    }
+    if (value >= 1.0f) {
+        return 0xFFFF;
+    }
+    return static_cast<uint16_t>(value * 65535.0f + 0.5f);
+}
+
+void PushUint16Le(std::vector<uint8_t>& outputArray, uint16_t value) {
+    outputArray.push_back(static_cast<uint8_t>(value & 0xFF));
+    outputArray.push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+}
+
+std::vector<uint8_t> CursorPositionPayload(float x, float y) {
     std::vector<uint8_t> outputArray;
-    outputArray.reserve(sizeof(float) * 2);
-
-    // Add x coordinate
-    uint8_t* xBytes = reinterpret_cast<uint8_t*>(&x);
-    if (test_endian()) {
-        // Little endian system
-        for (size_t i = 0; i < sizeof(x); ++i) {
-            outputArray.push_back(xBytes[i]);
-        }
-    }
-    else {
-        // Big endian system
-        for (size_t i = sizeof(x); i > 0; --i) {
-            outputArray.push_back(xBytes[i - 1]);
-        }
-    }
-
-    // Add y coordinate
-    uint8_t* yBytes = reinterpret_cast<uint8_t*>(&y);
-    if (test_endian()) {
-        // Little endian system
-        for (size_t i = 0; i < sizeof(y); ++i) {
-            outputArray.push_back(yBytes[i]);
-        }
-    }
-    else {
-        // Big endian system
-        for (size_t i = sizeof(y); i > 0; --i) {
-            outputArray.push_back(yBytes[i - 1]);
-        }
-    }
-
+    outputArray.reserve(sizeof(uint16_t) * 2);
+    PushUint16Le(outputArray, EncodeUnitU16(x));
+    PushUint16Le(outputArray, EncodeUnitU16(y));
     return outputArray;
 }
 
@@ -575,14 +561,14 @@ void CursorChangedEventProc(HWINEVENTHOOK hook,
         case EVENT_OBJECT_HIDE:
             for (auto callback : callbacks) {
                 MousePosition mousePos = GetMousePositionAndScreenId();
-                std::vector<uint8_t> positionBytes = FloatToBytes(mousePos.xPercent, mousePos.yPercent);
+                std::vector<uint8_t> positionBytes = CursorPositionPayload(mousePos.xPercent, mousePos.yPercent);
                 callback.second(CPP_CURSOR_INVISIBLE, mousePos.screenId, positionBytes);
             }
             break;
         case EVENT_OBJECT_SHOW:
             for (auto callback : callbacks) {
                 MousePosition mousePos = GetMousePositionAndScreenId();
-                std::vector<uint8_t> positionBytes = FloatToBytes(mousePos.xPercent, mousePos.yPercent);
+                std::vector<uint8_t> positionBytes = CursorPositionPayload(mousePos.xPercent, mousePos.yPercent);
                 callback.second(CPP_CURSOR_VISIBLE, mousePos.screenId, positionBytes);
             }
             SyncCursorImage();
@@ -649,7 +635,7 @@ void CursorMonitor::startHook(CursorChangedCallback callback, long long callback
 
     if (!IsCursorVisible()) {
         MousePosition mousePos = GetMousePositionAndScreenId();
-        std::vector<uint8_t> positionBytes = FloatToBytes(mousePos.xPercent, mousePos.yPercent);
+        std::vector<uint8_t> positionBytes = CursorPositionPayload(mousePos.xPercent, mousePos.yPercent);
         callback(CPP_CURSOR_INVISIBLE, mousePos.screenId, positionBytes);
     }
 }


### PR DESCRIPTION
## Summary
- Encode cursor position callbacks as two normalized little-endian `uint16` values instead of native `float` bytes.
- Clamp non-finite and out-of-range percentages at the platform boundary.
- Update the example decoder to read the 4-byte position payload.

## Rationale
Cursor positions are bounded percentages, so a normalized 16-bit representation is precise enough for screen placement and cuts the callback payload from 8 bytes to 4 bytes. More importantly, the payload no longer depends on native float memory layout or host endianness.

## Validation
- `flutter test`
- `cmake --build . --config Release --target hardware_simulator_plugin` from the main app Windows build directory
- `flutter analyze` was checked; the plugin still has a pre-existing example lint backlog, but this change does not introduce a build break