### PR TITLE
fix(macos): strip Fn/NumericPad from injected key events

### DIFF
--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -205,8 +205,20 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       if let macKeyCode = windowsToMacKeyMap[code] {
           let keyCode = CGKeyCode(macKeyCode)
 
-          // Create and post the keyboard event
+          // Create and post the keyboard event.
+          //
+          // Strip the Fn (secondaryFn) and NumericPad flags before posting.
+          // Arrow / navigation keys (kVK 0x7B–0x7E) are macOS function + numpad
+          // keys, so CGEvent auto-tags their events with Fn | NumericPad. Posting
+          // such an event latches Fn into the shared session modifier state — and
+          // because the key-up event carries Fn too, it is never released. Every
+          // subsequent injected key is built with `keyboardEventSource: nil`,
+          // which inherits that polluted session state, so the stray Fn leaks onto
+          // ordinary keys: e.g. "E" becomes 🌐+E and opens the Emoji & Symbols
+          // picker. We never intend to inject Fn, so clear it (and NumericPad)
+          // from every event; the virtual key code alone still drives arrows.
           let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: isDown)
+          event?.flags.remove([.maskSecondaryFn, .maskNumericPad])
           event?.post(tap: .cghidEventTap)
       } else {
           print("Key code \(code) not found in mapping.")


### PR DESCRIPTION
## 问题

被控端（macOS）只要**控制端按过一次方向键**，之后注入的普通键就会变成 🌐(Fn)+ 组合键——最典型的是按 `e` 直接打开「表情与符号」面板（🌐+E），而不是输入 `e`。直接在被控机实体键盘上按则正常。

## 根因（已用运行时日志证实）

`PerformKeyEvent` 用 `CGEvent(keyboardEventSource: nil, virtualKey:, keyDown:)` 注入按键。

1. macOS 方向键码 `kVK 0x7B–0x7E` 属于 function + numpad 键，`CGEvent` 创建时会**自动给事件加上 `Fn(secondaryFn) | NumericPad` 标志**。
2. 这个带 Fn 的事件一 `post`，**Fn 就被锁存进系统会话修饰键状态**（`combinedSessionState`），而且连 keyUp 也带 Fn，所以永远不会触发「Fn 松开」。
3. 之后每个注入事件都用 `keyboardEventSource: nil` 创建，会**继承这个被污染的会话状态** → Fn 泄漏到普通字母键上 → `E` 变成 🌐+E。
4. 实体键盘不受影响，因为真实硬件事件带的是真实 Fn 状态（未按）。

实测日志（节选）：

```
# 方向键前
win=0x45 mac=0x0E  eventFlags=0x20000100  fnInEvent=no    ← e 正常
# 方向键 ←(0x7B)
↓ mac=0x7B  eventFlags=0x20A00100  sessionFlags=0x20000100  fnInEvent=YES
↑ mac=0x7B  eventFlags=0x20A00100  sessionFlags=0x20A00100  ← Fn 锁存进会话
# 方向键后
win=0x45 mac=0x0E  eventFlags=0x20A00100  fnInEvent=YES   ← e 带 Fn → 🌐+E
```

## 修复

注入前从事件清掉 `Fn` 与 `NumericPad` 标志：

```swift
event?.flags.remove([.maskSecondaryFn, .maskNumericPad])
```

- 我们从不刻意注入 Fn，所以无条件清理总是安全的；
- 方向键靠虚拟键码本身仍正常工作，且不再把 Fn 锁存进会话状态；
- Shift/Ctrl/Cmd/Option 不受影响（它们经会话合并，仍保留）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)