### PR TITLE
feat(macos): add DMG virtual display backend

### DIFF
--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -26,6 +26,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var injectedMouseButtonIds = Set<Int>()
   private let maxDoubleClickDistance: CGFloat = 6
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private let macVirtualDisplayQueueKey = DispatchSpecificKey<Void>()
   private let macVirtualDisplayQueue = DispatchQueue(
     label: "com.cloudplayplus.hardware-simulator.virtual-display"
   )
@@ -46,6 +47,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   deinit {
     terminateAllMacVirtualDisplays()
+  }
+
+  override init() {
+    super.init()
+    macVirtualDisplayQueue.setSpecific(key: macVirtualDisplayQueueKey, value: ())
   }
 
   private struct MacVirtualDisplayConfig {
@@ -214,13 +220,18 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         self?.macVirtualDisplayProcesses.removeValue(forKey: displayId)
       }
     }
-    macVirtualDisplayProcesses[displayId] = process
+    macVirtualDisplayQueue.sync {
+      macVirtualDisplayProcesses[displayId] = process
+    }
     Thread.sleep(forTimeInterval: 1.0)
     return displayId
   }
 
   private func terminateMacVirtualDisplay(_ displayId: Int) -> Bool {
-    guard let process = macVirtualDisplayProcesses.removeValue(forKey: displayId) else {
+    let process: Process? = macVirtualDisplayQueue.sync {
+      macVirtualDisplayProcesses.removeValue(forKey: displayId)
+    }
+    guard let process else {
       return false
     }
     if process.isRunning {
@@ -236,6 +247,16 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
       macVirtualDisplayProcesses.removeAll()
     }
+  }
+
+  private func macVirtualDisplayIdsSnapshot() -> Set<Int> {
+    let snapshot = {
+      Set(self.macVirtualDisplayProcesses.keys)
+    }
+    if DispatchQueue.getSpecific(key: macVirtualDisplayQueueKey) != nil {
+      return snapshot()
+    }
+    return macVirtualDisplayQueue.sync(execute: snapshot)
   }
 
   private func screenNameByDisplayId() -> [Int: String] {
@@ -282,11 +303,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
     let names = screenNameByDisplayId()
     let mainId = Int(CGMainDisplayID())
+    let virtualDisplayIds = macVirtualDisplayIdsSnapshot()
     return displayIds.prefix(Int(displayCount)).enumerated().map { index, id in
       let displayId = Int(id)
       let mode = CGDisplayCopyDisplayMode(id)
       let bounds = CGDisplayBounds(id)
-      let isVirtual = macVirtualDisplayProcesses[displayId] != nil
+      let isVirtual = virtualDisplayIds.contains(displayId)
       let name = isVirtual
         ? "CloudPlayPlus Virtual Display"
         : (names[displayId] ?? "Display \(displayId)")
@@ -370,7 +392,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
     }
 
-    guard macVirtualDisplayProcesses[displayId] != nil else {
+    guard macVirtualDisplayIdsSnapshot().contains(displayId) else {
       return false
     }
     _ = terminateMacVirtualDisplay(displayId)

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -25,6 +25,15 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private let mouseEventSource = CGEventSource(stateID: .hidSystemState)
   private var injectedMouseButtonIds = Set<Int>()
   private let maxDoubleClickDistance: CGFloat = 6
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private let macVirtualDisplayQueue = DispatchQueue(
+    label: "com.cloudplayplus.hardware-simulator.virtual-display"
+  )
+  private var macVirtualDisplayProcesses: [Int: Process] = [:]
+  private let macCustomDisplayConfigsKey =
+    "com.cloudplayplus.hardware_simulator.macos.custom_display_configs"
+  private let macHelperName = "cloudplayplus_vd_helper"
+#endif
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "hardware_simulator", binaryMessenger: registrar.messenger)
@@ -33,6 +42,372 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     instance.defaultCursorHasher = CursorHasher()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
+
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  deinit {
+    terminateAllMacVirtualDisplays()
+  }
+
+  private struct MacVirtualDisplayConfig {
+    let width: Int
+    let height: Int
+    let refreshRate: Int
+  }
+
+  private func macHelperURL() -> URL? {
+    return Bundle.main.bundleURL
+      .appendingPathComponent("Contents")
+      .appendingPathComponent("MacOS")
+      .appendingPathComponent(macHelperName)
+  }
+
+  private func macVirtualDisplayAvailable() -> Bool {
+    guard #available(macOS 14.0, *) else {
+      return false
+    }
+    guard NSClassFromString("CGVirtualDisplay") != nil else {
+      return false
+    }
+    guard let helper = macHelperURL() else {
+      return false
+    }
+    return FileManager.default.isExecutableFile(atPath: helper.path)
+  }
+
+  private func macDefaultDisplayConfig() -> MacVirtualDisplayConfig {
+    return MacVirtualDisplayConfig(width: 1920, height: 1080, refreshRate: 60)
+  }
+
+  private func readMacHelperDisplayId(from output: Pipe, timeout: DispatchTime) -> String? {
+    let handle = output.fileHandleForReading
+    let semaphore = DispatchSemaphore(value: 0)
+    let lock = NSLock()
+    var data = Data()
+    var finished = false
+
+    handle.readabilityHandler = { readableHandle in
+      let chunk = readableHandle.availableData
+      lock.lock()
+      defer { lock.unlock() }
+      guard !finished else {
+        return
+      }
+      if chunk.isEmpty {
+        finished = true
+        semaphore.signal()
+        return
+      }
+      data.append(chunk)
+      if data.contains(0x0A) {
+        finished = true
+        semaphore.signal()
+      }
+    }
+
+    let status = semaphore.wait(timeout: timeout)
+    handle.readabilityHandler = nil
+    if status == .timedOut {
+      return nil
+    }
+
+    lock.lock()
+    let captured = data
+    lock.unlock()
+    return String(data: captured, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func macCustomDisplayConfigs() -> [[String: Int]] {
+    guard
+      let raw = UserDefaults.standard.array(forKey: macCustomDisplayConfigsKey)
+        as? [[String: Any]]
+    else {
+      return []
+    }
+    return raw.compactMap { item in
+      guard
+        let width = item["width"] as? Int,
+        let height = item["height"] as? Int,
+        let refreshRate = item["refreshRate"] as? Int,
+        width > 0,
+        height > 0,
+        refreshRate > 0
+      else {
+        return nil
+      }
+      return [
+        "width": width,
+        "height": height,
+        "refreshRate": refreshRate,
+      ]
+    }
+  }
+
+  private func setMacCustomDisplayConfigs(_ configs: [[String: Any]]) -> Bool {
+    let sanitized = configs.compactMap { item -> [String: Int]? in
+      let width = item["width"] as? Int
+      let height = item["height"] as? Int
+      let refreshRate = item["refreshRate"] as? Int
+      guard
+        let width = width,
+        let height = height,
+        let refreshRate = refreshRate,
+        width > 0,
+        height > 0,
+        refreshRate > 0
+      else {
+        return nil
+      }
+      return [
+        "width": width,
+        "height": height,
+        "refreshRate": refreshRate,
+      ]
+    }
+    UserDefaults.standard.set(sanitized, forKey: macCustomDisplayConfigsKey)
+    return sanitized.count == configs.count
+  }
+
+  private func spawnMacVirtualDisplay(
+    width: Int,
+    height: Int,
+    refreshRate: Int
+  ) -> Int {
+    guard macVirtualDisplayAvailable(), let helper = macHelperURL() else {
+      return -1
+    }
+
+    let process = Process()
+    let output = Pipe()
+    process.executableURL = helper
+    process.arguments = [
+      "\(width)",
+      "\(height)",
+      "\(refreshRate)",
+      "\(ProcessInfo.processInfo.processIdentifier)",
+    ]
+    process.standardOutput = output
+    process.standardError = FileHandle.standardError
+
+    do {
+      try process.run()
+    } catch {
+      return -1
+    }
+
+    guard
+      let text = readMacHelperDisplayId(
+        from: output,
+        timeout: .now() + .seconds(10)
+      )
+    else {
+      process.terminate()
+      return -1
+    }
+    guard let displayId = Int(text), displayId > 0 else {
+      process.terminate()
+      return -1
+    }
+
+    process.terminationHandler = { [weak self] _ in
+      self?.macVirtualDisplayQueue.async {
+        self?.macVirtualDisplayProcesses.removeValue(forKey: displayId)
+      }
+    }
+    macVirtualDisplayProcesses[displayId] = process
+    Thread.sleep(forTimeInterval: 1.0)
+    return displayId
+  }
+
+  private func terminateMacVirtualDisplay(_ displayId: Int) -> Bool {
+    guard let process = macVirtualDisplayProcesses.removeValue(forKey: displayId) else {
+      return false
+    }
+    if process.isRunning {
+      process.terminate()
+    }
+    return true
+  }
+
+  private func terminateAllMacVirtualDisplays() {
+    macVirtualDisplayQueue.sync {
+      for process in macVirtualDisplayProcesses.values where process.isRunning {
+        process.terminate()
+      }
+      macVirtualDisplayProcesses.removeAll()
+    }
+  }
+
+  private func screenNameByDisplayId() -> [Int: String] {
+    var names: [Int: String] = [:]
+    for screen in NSScreen.screens {
+      guard
+        let number = screen.deviceDescription[
+          NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? NSNumber
+      else {
+        continue
+      }
+      if #available(macOS 10.15, *) {
+        names[number.intValue] = screen.localizedName
+      } else {
+        names[number.intValue] = "Display \(number.intValue)"
+      }
+    }
+    return names
+  }
+
+  private func displayRefreshRate(_ mode: CGDisplayMode?) -> Int {
+    guard let mode else {
+      return 60
+    }
+    let refresh = mode.refreshRate
+    if refresh.isFinite && refresh > 0 {
+      return Int(refresh.rounded())
+    }
+    return 60
+  }
+
+  private func macDisplayList() -> [[String: Any]] {
+    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: 32)
+    var displayCount: UInt32 = 0
+    let err = CGGetActiveDisplayList(
+      UInt32(displayIds.count),
+      &displayIds,
+      &displayCount
+    )
+    guard err == .success else {
+      return []
+    }
+
+    let names = screenNameByDisplayId()
+    let mainId = Int(CGMainDisplayID())
+    return displayIds.prefix(Int(displayCount)).enumerated().map { index, id in
+      let displayId = Int(id)
+      let mode = CGDisplayCopyDisplayMode(id)
+      let bounds = CGDisplayBounds(id)
+      let isVirtual = macVirtualDisplayProcesses[displayId] != nil
+      let name = isVirtual
+        ? "CloudPlayPlus Virtual Display"
+        : (names[displayId] ?? "Display \(displayId)")
+      return [
+        "index": index,
+        "width": CGDisplayPixelsWide(id),
+        "height": CGDisplayPixelsHigh(id),
+        "refreshRate": displayRefreshRate(mode),
+        "isVirtual": isVirtual,
+        "displayName": name,
+        "deviceName": "\(displayId)",
+        "active": CGDisplayIsActive(id) != 0,
+        "displayUid": displayId,
+        "orientation": 0,
+        "left": Int(bounds.minX.rounded()),
+        "top": Int(bounds.minY.rounded()),
+        "right": Int(bounds.maxX.rounded()),
+        "bottom": Int(bounds.maxY.rounded()),
+        "isPrimary": displayId == mainId,
+      ]
+    }
+  }
+
+  private func macDisplayConfigs(_ displayId: CGDirectDisplayID) -> [[String: Int]] {
+    var configs: [[String: Int]] = []
+    let options = [
+      kCGDisplayShowDuplicateLowResolutionModes as String: true,
+    ] as CFDictionary
+    if let modes = CGDisplayCopyAllDisplayModes(displayId, options) as? [CGDisplayMode] {
+      for mode in modes {
+        let width = mode.pixelWidth > 0 ? mode.pixelWidth : mode.width
+        let height = mode.pixelHeight > 0 ? mode.pixelHeight : mode.height
+        let refreshRate = displayRefreshRate(mode)
+        if width > 0 && height > 0 && refreshRate > 0 {
+          configs.append([
+            "width": width,
+            "height": height,
+            "refreshRate": refreshRate,
+          ])
+        }
+      }
+    }
+    configs.append(contentsOf: macCustomDisplayConfigs())
+    var seen = Set<String>()
+    return configs.filter { item in
+      let key = "\(item["width"] ?? 0)x\(item["height"] ?? 0)@\(item["refreshRate"] ?? 0)"
+      if seen.contains(key) {
+        return false
+      }
+      seen.insert(key)
+      return true
+    }.sorted { lhs, rhs in
+      let lw = lhs["width"] ?? 0
+      let rw = rhs["width"] ?? 0
+      if lw != rw { return lw < rw }
+      let lh = lhs["height"] ?? 0
+      let rh = rhs["height"] ?? 0
+      if lh != rh { return lh < rh }
+      return (lhs["refreshRate"] ?? 0) < (rhs["refreshRate"] ?? 0)
+    }
+  }
+
+  private func setMacDisplayMode(
+    displayId: Int,
+    width: Int,
+    height: Int,
+    refreshRate: Int
+  ) -> Bool {
+    let cgDisplayId = CGDirectDisplayID(displayId)
+    let options = [
+      kCGDisplayShowDuplicateLowResolutionModes as String: true,
+    ] as CFDictionary
+    if let modes = CGDisplayCopyAllDisplayModes(cgDisplayId, options) as? [CGDisplayMode] {
+      for mode in modes {
+        let modeWidth = mode.pixelWidth > 0 ? mode.pixelWidth : mode.width
+        let modeHeight = mode.pixelHeight > 0 ? mode.pixelHeight : mode.height
+        let modeRefresh = displayRefreshRate(mode)
+        if modeWidth == width && modeHeight == height && modeRefresh == refreshRate {
+          return CGDisplaySetDisplayMode(cgDisplayId, mode, nil) == .success
+        }
+      }
+    }
+
+    guard macVirtualDisplayProcesses[displayId] != nil else {
+      return false
+    }
+    _ = terminateMacVirtualDisplay(displayId)
+    return spawnMacVirtualDisplay(
+      width: width,
+      height: height,
+      refreshRate: refreshRate
+    ) > 0
+  }
+
+  private func setMacMirroring(_ enabled: Bool) -> Bool {
+    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: 32)
+    var displayCount: UInt32 = 0
+    guard
+      CGGetActiveDisplayList(UInt32(displayIds.count), &displayIds, &displayCount)
+        == .success,
+      displayCount >= 2
+    else {
+      return false
+    }
+
+    var config: CGDisplayConfigRef?
+    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
+      return false
+    }
+
+    let primary = displayIds[0]
+    for id in displayIds.prefix(Int(displayCount)).dropFirst() {
+      CGConfigureDisplayMirrorOfDisplay(
+        config,
+        id,
+        enabled ? primary : kCGNullDirectDisplay
+      )
+    }
+    return CGCompleteDisplayConfiguration(config, .forAppOnly) == .success
+  }
+#endif
 
   // Reverse mapping: Windows code to macOS code
   let windowsToMacKeyMap: [Int: Int] = [
@@ -919,6 +1294,130 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       let activity = ProcessInfo.processInfo.beginActivity(options: [.idleDisplaySleepDisabled, .userInitiated], reason: reason)
       activities[key] = activity
       result(NSScreen.screens.count)
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    case "initParsecVdd":
+      result(macVirtualDisplayAvailable())
+    case "createDisplay":
+      macVirtualDisplayQueue.async {
+        let config = self.macDefaultDisplayConfig()
+        let id = self.spawnMacVirtualDisplay(
+          width: config.width,
+          height: config.height,
+          refreshRate: config.refreshRate
+        )
+        DispatchQueue.main.async { result(id) }
+      }
+    case "removeDisplay":
+      let args = call.arguments as? [String: Any]
+      let displayUid = args?["displayUid"] as? Int ?? -1
+      macVirtualDisplayQueue.async {
+        let ok = self.terminateMacVirtualDisplay(displayUid)
+        DispatchQueue.main.async { result(ok) }
+      }
+    case "getAllDisplays":
+      result(macDisplayList().count)
+    case "getDisplayList":
+      result(macDisplayList())
+    case "changeDisplaySettings":
+      guard
+        let args = call.arguments as? [String: Any],
+        let displayUid = args["displayUid"] as? Int,
+        let width = args["width"] as? Int,
+        let height = args["height"] as? Int,
+        let refreshRate = args["refreshRate"] as? Int
+      else {
+        result(false)
+        return
+      }
+      macVirtualDisplayQueue.async {
+        let ok = self.setMacDisplayMode(
+          displayId: displayUid,
+          width: width,
+          height: height,
+          refreshRate: refreshRate
+        )
+        DispatchQueue.main.async { result(ok) }
+      }
+    case "getDisplayConfigs":
+      let args = call.arguments as? [String: Any]
+      let displayUid = args?["displayUid"] as? Int ?? Int(CGMainDisplayID())
+      result(macDisplayConfigs(CGDirectDisplayID(displayUid)))
+    case "getCustomDisplayConfigs":
+      result(macCustomDisplayConfigs())
+    case "setCustomDisplayConfigs":
+      let args = call.arguments as? [String: Any]
+      let configs = args?["configs"] as? [[String: Any]] ?? []
+      result(setMacCustomDisplayConfigs(configs))
+    case "setDisplayOrientation":
+      result(false)
+    case "getDisplayOrientation":
+      result(0)
+    case "setMultiDisplayMode":
+      let args = call.arguments as? [String: Any]
+      let mode = args?["mode"] as? Int ?? 4
+      switch mode {
+      case 0:
+        result(setMacMirroring(false))
+      case 3:
+        result(setMacMirroring(true))
+      default:
+        result(false)
+      }
+    case "getCurrentMultiDisplayMode":
+      let displays = macDisplayList()
+      if displays.count <= 1 {
+        result(1)
+      } else {
+        let anyMirrored = displays.contains { item in
+          guard let uid = item["displayUid"] as? Int else { return false }
+          return CGDisplayMirrorsDisplay(CGDirectDisplayID(uid)) != 0
+        }
+        result(anyMirrored ? 3 : 0)
+      }
+    case "setPrimaryDisplayOnly":
+      result(false)
+    case "restoreDisplayConfiguration":
+      result(false)
+    case "hasPendingConfiguration":
+      result(false)
+    case "updateStaticMonitors":
+      result(nil)
+#else
+    case "initParsecVdd":
+      result(false)
+    case "createDisplay":
+      result(-1)
+    case "removeDisplay":
+      result(false)
+    case "getAllDisplays":
+      result(NSScreen.screens.count)
+    case "getDisplayList":
+      result([])
+    case "changeDisplaySettings":
+      result(false)
+    case "getDisplayConfigs":
+      result([])
+    case "getCustomDisplayConfigs":
+      result([])
+    case "setCustomDisplayConfigs":
+      result(false)
+    case "setDisplayOrientation":
+      result(false)
+    case "getDisplayOrientation":
+      result(0)
+    case "setMultiDisplayMode":
+      result(false)
+    case "getCurrentMultiDisplayMode":
+      result(4)
+    case "setPrimaryDisplayOnly":
+      result(false)
+    case "restoreDisplayConfiguration":
+      result(false)
+    case "hasPendingConfiguration":
+      result(false)
+    case "updateStaticMonitors":
+      result(nil)
+#endif
     case "mouseMoveA":
       if let args = call.arguments as? [String: Any],
         let percentX = args["x"] as? Double,

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -250,13 +250,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func macVirtualDisplayIdsSnapshot() -> Set<Int> {
-    let snapshot = {
-      Set(self.macVirtualDisplayProcesses.keys)
-    }
     if DispatchQueue.getSpecific(key: macVirtualDisplayQueueKey) != nil {
-      return snapshot()
+      return Set(macVirtualDisplayProcesses.keys)
     }
-    return macVirtualDisplayQueue.sync(execute: snapshot)
+    return macVirtualDisplayQueue.sync {
+      Set(macVirtualDisplayProcesses.keys)
+    }
   }
 
   private func screenNameByDisplayId() -> [Int: String] {

--- a/macos/VirtualDisplayHelper/CloudPlayPlusVirtualDisplayHelper.m
+++ b/macos/VirtualDisplayHelper/CloudPlayPlusVirtualDisplayHelper.m
@@ -1,0 +1,306 @@
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+#include <errno.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+@interface CGVirtualDisplayMode : NSObject
+- (instancetype)initWithWidth:(unsigned int)width
+                       height:(unsigned int)height
+                  refreshRate:(double)refreshRate;
+@end
+
+@interface CGVirtualDisplaySettings : NSObject
+@property(nonatomic) unsigned int hiDPI;
+@property(nonatomic, retain) NSArray *modes;
+@end
+
+@interface CGVirtualDisplayDescriptor : NSObject
+@property(nonatomic, retain) NSString *name;
+@property(nonatomic) unsigned int vendorID;
+@property(nonatomic) unsigned int productID;
+@property(nonatomic) unsigned int serialNum;
+@property(nonatomic) unsigned int maxPixelsWide;
+@property(nonatomic) unsigned int maxPixelsHigh;
+@property(nonatomic) CGSize sizeInMillimeters;
+@property(nonatomic) CGPoint whitePoint;
+@property(nonatomic) CGPoint redPrimary;
+@property(nonatomic) CGPoint greenPrimary;
+@property(nonatomic) CGPoint bluePrimary;
+@property(nonatomic, copy) void (^terminationHandler)(id, id);
+- (void)setDispatchQueue:(dispatch_queue_t)queue;
+@end
+
+@interface CGVirtualDisplay : NSObject
+@property(readonly, nonatomic) unsigned int displayID;
+- (instancetype)initWithDescriptor:(CGVirtualDisplayDescriptor *)descriptor;
+- (BOOL)applySettings:(CGVirtualDisplaySettings *)settings;
+@end
+
+extern CGError SLSBeginDisplayConfiguration(CGDisplayConfigRef *);
+extern CGError SLSConfigureDisplayEnabled(CGDisplayConfigRef,
+                                          CGDirectDisplayID,
+                                          bool);
+extern CGError SLSConfigureDisplayOrigin(CGDisplayConfigRef,
+                                         CGDirectDisplayID,
+                                         int32_t,
+                                         int32_t);
+extern CGError SLSCompleteDisplayConfiguration(CGDisplayConfigRef,
+                                               CGConfigureOption,
+                                               uint32_t);
+
+static CGVirtualDisplay *g_display = nil;
+static CGVirtualDisplayDescriptor *g_descriptor = nil;
+static volatile sig_atomic_t g_should_exit = 0;
+
+static void handleSignal(int signo) {
+  g_should_exit = 1;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    CFRunLoopStop(CFRunLoopGetMain());
+  });
+}
+
+static BOOL parsePositiveInt(const char *text, int *outValue) {
+  if (text == NULL || outValue == NULL) return NO;
+  char *end = NULL;
+  long value = strtol(text, &end, 10);
+  if (end == text || *end != '\0' || value <= 0 || value > INT_MAX) {
+    return NO;
+  }
+  *outValue = (int)value;
+  return YES;
+}
+
+static BOOL parentIsAlive(pid_t parentPID) {
+  if (parentPID <= 1) return YES;
+  return kill(parentPID, 0) == 0 || errno == EPERM;
+}
+
+static void addMode(NSMutableArray *modes,
+                    unsigned int width,
+                    unsigned int height,
+                    double refreshRate,
+                    unsigned int maxWidth,
+                    unsigned int maxHeight) {
+  if (width == 0 || height == 0 || width > maxWidth || height > maxHeight) {
+    return;
+  }
+  CGVirtualDisplayMode *mode =
+      [[CGVirtualDisplayMode alloc] initWithWidth:width
+                                           height:height
+                                      refreshRate:refreshRate];
+  if (mode != nil) {
+    [modes addObject:mode];
+  }
+}
+
+static NSArray *buildModes(int width, int height, int refreshRate) {
+  NSMutableArray *modes = [NSMutableArray array];
+  const unsigned int maxWidth = (unsigned int)width;
+  const unsigned int maxHeight = (unsigned int)height;
+  const double hz = (double)refreshRate;
+
+  addMode(modes, maxWidth, maxHeight, hz, maxWidth, maxHeight);
+  addMode(modes, maxWidth / 2, maxHeight / 2, hz, maxWidth, maxHeight);
+
+  return modes;
+}
+
+static void activateDisplay(CGDirectDisplayID displayID) {
+  CGDisplayConfigRef config = NULL;
+  if (SLSBeginDisplayConfiguration(&config) != kCGErrorSuccess ||
+      config == NULL) {
+    return;
+  }
+
+  SLSConfigureDisplayEnabled(config, displayID, true);
+  CGDirectDisplayID mainDisplay = CGMainDisplayID();
+  CGRect mainBounds = CGDisplayBounds(mainDisplay);
+  SLSConfigureDisplayOrigin(config,
+                            displayID,
+                            (int32_t)CGRectGetMaxX(mainBounds),
+                            0);
+  SLSCompleteDisplayConfiguration(config, kCGConfigureForSession, 0);
+}
+
+static void forceExtended(CGDirectDisplayID displayID) {
+  CGDisplayConfigRef config = NULL;
+  if (CGBeginDisplayConfiguration(&config) != kCGErrorSuccess ||
+      config == NULL) {
+    return;
+  }
+  CGConfigureDisplayMirrorOfDisplay(config, displayID, kCGNullDirectDisplay);
+  CGCompleteDisplayConfiguration(config, kCGConfigureForAppOnly);
+
+  config = NULL;
+  if (CGBeginDisplayConfiguration(&config) != kCGErrorSuccess ||
+      config == NULL) {
+    return;
+  }
+  CGDirectDisplayID mainDisplay = CGMainDisplayID();
+  CGRect mainBounds = CGDisplayBounds(mainDisplay);
+  CGConfigureDisplayOrigin(config,
+                           displayID,
+                           (int32_t)CGRectGetMaxX(mainBounds),
+                           0);
+  CGCompleteDisplayConfiguration(config, kCGConfigureForAppOnly);
+}
+
+static void preferNativeScale(CGDirectDisplayID displayID,
+                              int width,
+                              int height) {
+  NSDictionary *options =
+      @{(NSString *)kCGDisplayShowDuplicateLowResolutionModes : @YES};
+  CFArrayRef modes =
+      CGDisplayCopyAllDisplayModes(displayID, (__bridge CFDictionaryRef)options);
+  if (modes == NULL) return;
+
+  CGDisplayModeRef selected = NULL;
+  CFIndex count = CFArrayGetCount(modes);
+  for (CFIndex i = 0; i < count; i++) {
+    CGDisplayModeRef mode = (CGDisplayModeRef)CFArrayGetValueAtIndex(modes, i);
+    if ((int)CGDisplayModeGetWidth(mode) == width &&
+        (int)CGDisplayModeGetHeight(mode) == height &&
+        CGDisplayModeGetPixelWidth(mode) == CGDisplayModeGetWidth(mode) &&
+        CGDisplayModeGetPixelHeight(mode) == CGDisplayModeGetHeight(mode)) {
+      selected = mode;
+      break;
+    }
+  }
+  if (selected != NULL) {
+    CGDisplaySetDisplayMode(displayID, selected, NULL);
+  }
+  CFRelease(modes);
+}
+
+int main(int argc, const char *argv[]) {
+  @autoreleasepool {
+    if (argc < 5 || NSClassFromString(@"CGVirtualDisplay") == Nil) {
+      fprintf(stdout, "0\n");
+      fflush(stdout);
+      return 1;
+    }
+
+    int width = 0;
+    int height = 0;
+    int refreshRate = 0;
+    int parentPIDInt = 0;
+    if (!parsePositiveInt(argv[1], &width) ||
+        !parsePositiveInt(argv[2], &height) ||
+        !parsePositiveInt(argv[3], &refreshRate) ||
+        !parsePositiveInt(argv[4], &parentPIDInt)) {
+      fprintf(stdout, "0\n");
+      fflush(stdout);
+      return 1;
+    }
+
+    signal(SIGTERM, handleSignal);
+    signal(SIGINT, handleSignal);
+    signal(SIGHUP, handleSignal);
+
+    CGVirtualDisplayDescriptor *descriptor =
+        [[CGVirtualDisplayDescriptor alloc] init];
+    descriptor.name = @"CloudPlayPlus Virtual Display";
+    descriptor.vendorID = 0x4350;
+    descriptor.productID = 0x5644;
+    descriptor.serialNum = arc4random();
+    descriptor.maxPixelsWide = (unsigned int)width;
+    descriptor.maxPixelsHigh = (unsigned int)height;
+    descriptor.sizeInMillimeters = CGSizeMake(597, 336);
+    descriptor.whitePoint = CGPointMake(0.3127, 0.3290);
+    descriptor.redPrimary = CGPointMake(0.64, 0.33);
+    descriptor.greenPrimary = CGPointMake(0.30, 0.60);
+    descriptor.bluePrimary = CGPointMake(0.15, 0.06);
+    [descriptor setDispatchQueue:dispatch_get_global_queue(QOS_CLASS_USER_INITIATED,
+                                                           0)];
+    descriptor.terminationHandler = ^(__unused id sender, __unused id reason) {
+      g_should_exit = 1;
+      dispatch_async(dispatch_get_main_queue(), ^{
+        CFRunLoopStop(CFRunLoopGetMain());
+      });
+    };
+
+    CGVirtualDisplaySettings *settings =
+        [[CGVirtualDisplaySettings alloc] init];
+    settings.hiDPI = 1;
+    settings.modes = buildModes(width, height, refreshRate);
+
+    fprintf(stderr,
+            "[cloudplayplus_vd_helper] creating %dx%d@%d\n",
+            width,
+            height,
+            refreshRate);
+
+    __block CGVirtualDisplay *display = nil;
+    __block BOOL settingsApplied = NO;
+    dispatch_semaphore_t created = dispatch_semaphore_create(0);
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+      display = [[CGVirtualDisplay alloc] initWithDescriptor:descriptor];
+      if (display != nil) {
+        settingsApplied = [display applySettings:settings];
+      }
+      dispatch_semaphore_signal(created);
+    });
+
+    if (dispatch_semaphore_wait(created,
+                                dispatch_time(DISPATCH_TIME_NOW,
+                                              8LL * NSEC_PER_SEC)) != 0) {
+      fprintf(stderr, "[cloudplayplus_vd_helper] create timeout\n");
+      fprintf(stdout, "0\n");
+      fflush(stdout);
+      return 1;
+    }
+
+    if (display == nil || !settingsApplied || display.displayID == 0) {
+      fprintf(stderr,
+              "[cloudplayplus_vd_helper] create failed display=%p applied=%d id=%u\n",
+              display,
+              settingsApplied,
+              display ? display.displayID : 0);
+      fprintf(stdout, "0\n");
+      fflush(stdout);
+      return 1;
+    }
+
+    g_descriptor = descriptor;
+    g_display = display;
+    CGDirectDisplayID displayID = display.displayID;
+    fprintf(stderr, "[cloudplayplus_vd_helper] created display %u\n", displayID);
+
+    activateDisplay(displayID);
+    usleep(500000);
+    forceExtended(displayID);
+    usleep(250000);
+    preferNativeScale(displayID, width, height);
+
+    fprintf(stdout, "%u\n", displayID);
+    fflush(stdout);
+    close(STDOUT_FILENO);
+
+    pid_t parentPID = (pid_t)parentPIDInt;
+    dispatch_source_t timer = dispatch_source_create(
+        DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+    dispatch_source_set_timer(timer,
+                              dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC),
+                              NSEC_PER_SEC,
+                              NSEC_PER_MSEC * 100);
+    dispatch_source_set_event_handler(timer, ^{
+      if (g_should_exit || !parentIsAlive(parentPID)) {
+        CFRunLoopStop(CFRunLoopGetMain());
+      }
+    });
+    dispatch_resume(timer);
+
+    while (!g_should_exit) {
+      CFRunLoopRun();
+      break;
+    }
+
+    dispatch_source_cancel(timer);
+    g_display = nil;
+    g_descriptor = nil;
+    return 0;
+  }
+}

--- a/macos/hardware_simulator.podspec
+++ b/macos/hardware_simulator.podspec
@@ -18,6 +18,9 @@ A new Flutter plugin project.
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.11'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'OTHER_SWIFT_FLAGS' => '$(inherited) $(CLOUDPLAYPLUS_DMG_SWIFT_FLAGS)',
+  }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
## Summary
- add a macOS DMG-only virtual display backend behind CLOUDPLAYPLUS_DMG_DISTRIBUTION
- add a bundled helper that creates CGVirtualDisplay instances and keeps them alive out of process
- expose display create/remove/list/config operations through the existing hardware_simulator method channel

## Verification
- flutter analyze (from cloudplayplus)
- dart format --set-exit-if-changed lib/ test/ (from cloudplayplus)
- ./build.sh --macos --dmg (from cloudplayplus)
- bundled helper smoke test created a virtual display and returned a display id
