### PR TITLE
fix(macos): avoid virtual display queue reentry crash

### DIFF
--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -174,6 +174,13 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return sanitized.count == configs.count
   }
 
+  private func withMacVirtualDisplayProcesses<T>(_ body: () -> T) -> T {
+    if DispatchQueue.getSpecific(key: macVirtualDisplayQueueKey) != nil {
+      return body()
+    }
+    return macVirtualDisplayQueue.sync(execute: body)
+  }
+
   private func spawnMacVirtualDisplay(
     width: Int,
     height: Int,
@@ -220,7 +227,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         self?.macVirtualDisplayProcesses.removeValue(forKey: displayId)
       }
     }
-    macVirtualDisplayQueue.sync {
+    withMacVirtualDisplayProcesses {
       macVirtualDisplayProcesses[displayId] = process
     }
     Thread.sleep(forTimeInterval: 1.0)
@@ -228,7 +235,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func terminateMacVirtualDisplay(_ displayId: Int) -> Bool {
-    let process: Process? = macVirtualDisplayQueue.sync {
+    let process: Process? = withMacVirtualDisplayProcesses {
       macVirtualDisplayProcesses.removeValue(forKey: displayId)
     }
     guard let process else {
@@ -241,7 +248,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func terminateAllMacVirtualDisplays() {
-    macVirtualDisplayQueue.sync {
+    withMacVirtualDisplayProcesses {
       for process in macVirtualDisplayProcesses.values where process.isRunning {
         process.terminate()
       }
@@ -250,10 +257,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func macVirtualDisplayIdsSnapshot() -> Set<Int> {
-    if DispatchQueue.getSpecific(key: macVirtualDisplayQueueKey) != nil {
-      return Set(macVirtualDisplayProcesses.keys)
-    }
-    return macVirtualDisplayQueue.sync {
+    return withMacVirtualDisplayProcesses {
       Set(macVirtualDisplayProcesses.keys)
     }
   }


### PR DESCRIPTION
## Summary
- avoid dispatch_sync reentry on the macOS virtual display serial queue
- route process dictionary reads/writes through a queue-aware helper
- fixes the crash when create/remove/change virtual display is invoked from macVirtualDisplayQueue

## Root cause
Crash reports show `SIGTRAP` with `BUG IN CLIENT OF LIBDISPATCH: dispatch_sync called on queue already owned by current thread`, faulting at `HardwareSimulatorPlugin.swift:223` during `spawnMacVirtualDisplay`. `createDisplay` already runs on `macVirtualDisplayQueue`, then the spawn path tried to `sync` onto the same queue.

## Verification
- `git diff --check`
- `./build.sh --macos --dmg` from the parent cloudplayplus repo succeeded
- signed release app: `build/macos/Build/Products/Release/cloudplayplus.app`

## Squash message
`fix(macos): avoid virtual display queue reentry crash`

Body: leave empty.