### PR TITLE
fix(windows): inject native pen hover events

### DIFF
--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -284,6 +284,10 @@ class HardwareSimulator {
         .performPenMove(x, y, hasButton, pressure, rotation, tilt, screenId);
   }
 
+  static void performPenHover(double x, double y, int screenId) {
+    HardwareSimulatorPlatform.instance.performPenHover(x, y, screenId);
+  }
+
   static Future<GameController?> createGameController() {
     return GameController.createGameController();
   }

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -96,6 +96,7 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
         .invokeMethod('openMacOSPrivacySettings', {'section': section});
   }
 
+  @override
   Future<bool?> getIsMouseConnected() {
     return methodChannel.invokeMethod<bool>('isMouseConnected');
   }
@@ -411,6 +412,15 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
       'pressure': pressure,
       'rotation': rotation,
       'tilt': tilt,
+      'screenId': screenId,
+    });
+  }
+
+  @override
+  Future<void> performPenHover(double x, double y, int screenId) async {
+    await methodChannel.invokeMethod('penHover', {
+      'x': x,
+      'y': y,
       'screenId': screenId,
     });
   }

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -234,6 +234,10 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('performPenMove() has not been implemented.');
   }
 
+  Future<void> performPenHover(double x, double y, int screenId) async {
+    throw UnimplementedError('performPenHover() has not been implemented.');
+  }
+
   Future<int> createGameController() async {
     throw UnimplementedError(
         'createGameController() has not been implemented.');

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -592,6 +592,7 @@ static void hardware_simulator_plugin_handle_method_call(
              strcmp(method, "touchMove") == 0 ||
              strcmp(method, "penEvent") == 0 ||
              strcmp(method, "penMove") == 0 ||
+             strcmp(method, "penHover") == 0 ||
              strcmp(method, "hookCursorImage") == 0 ||
              strcmp(method, "unhookCursorImage") == 0 ||
              strcmp(method, "hookCursorPosition") == 0 ||

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -26,4 +26,26 @@ void main() {
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
   });
+
+  test('performPenHover sends penHover method call', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        return null;
+      },
+    );
+
+    await platform.performPenHover(0.25, 0.75, 2);
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'penHover');
+    expect(calls.single.arguments, {
+      'x': 0.25,
+      'y': 0.75,
+      'screenId': 2,
+    });
+  });
 }

--- a/windows/cursor_monitor.cc
+++ b/windows/cursor_monitor.cc
@@ -15,6 +15,8 @@ const int kBytesPerPixel = 4;
 static std::map<long long, std::unordered_set<uint32_t>> cachedcursors;
 static std::map<long long, CursorChangedCallback> callbacks;
 static std::map<long long, bool> hookAllCursorImage;
+static bool lastCursorVisible = true;
+static bool hasLastCursorVisible = false;
 
 // Position monitoring callbacks and state
 static std::map<long long, CursorPositionCallback> positionCallbacks;
@@ -548,6 +550,35 @@ bool IsCursorVisible() {
     return true;
 }
 
+void SyncCursorVisibility() {
+    bool visible = IsCursorVisible();
+    if (hasLastCursorVisible && visible == lastCursorVisible) {
+        return;
+    }
+
+    hasLastCursorVisible = true;
+    lastCursorVisible = visible;
+    MousePosition mousePos = GetMousePositionAndScreenId();
+    std::vector<uint8_t> positionBytes = CursorPositionPayload(mousePos.xPercent, mousePos.yPercent);
+    for (auto callback : callbacks) {
+        callback.second(
+            visible ? CPP_CURSOR_VISIBLE : CPP_CURSOR_INVISIBLE,
+            mousePos.screenId,
+            positionBytes);
+    }
+}
+
+void CursorMonitor::syncNow() {
+    if (callbacks.empty()) {
+        return;
+    }
+
+    SyncCursorVisibility();
+    if (lastCursorVisible) {
+        SyncCursorImage();
+    }
+}
+
 void CursorChangedEventProc(HWINEVENTHOOK hook,
     DWORD event,
     HWND hwnd,
@@ -559,6 +590,8 @@ void CursorChangedEventProc(HWINEVENTHOOK hook,
         std::string str;
         switch (event) {
         case EVENT_OBJECT_HIDE:
+            hasLastCursorVisible = true;
+            lastCursorVisible = false;
             for (auto callback : callbacks) {
                 MousePosition mousePos = GetMousePositionAndScreenId();
                 std::vector<uint8_t> positionBytes = CursorPositionPayload(mousePos.xPercent, mousePos.yPercent);
@@ -566,6 +599,8 @@ void CursorChangedEventProc(HWINEVENTHOOK hook,
             }
             break;
         case EVENT_OBJECT_SHOW:
+            hasLastCursorVisible = true;
+            lastCursorVisible = true;
             for (auto callback : callbacks) {
                 MousePosition mousePos = GetMousePositionAndScreenId();
                 std::vector<uint8_t> positionBytes = CursorPositionPayload(mousePos.xPercent, mousePos.yPercent);

--- a/windows/cursor_monitor.h
+++ b/windows/cursor_monitor.h
@@ -23,7 +23,8 @@ public:
     static HWINEVENTHOOK Global_HOOK;
     static void startHook(CursorChangedCallback callback, long long callback_id, bool hookAll);
     static void endHook(long long callback_id);
-    
+    static void syncNow();
+
     // Position monitoring functions
     static void startPositionHook(CursorPositionCallback callback, long long callback_id);
     static void endPositionHook(long long callback_id);

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -45,6 +45,8 @@ void performKeyEvent(uint16_t modcode, bool isDown, bool isRepeat);
 void performTouchEvent(int screenId, double x, double y, uint32_t touchId, bool isDown, bool isRepeat);
 void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButton, double pressure, double rotation, double tilt);
 void performPenMove(int screenId, double x, double y, bool hasButton, double pressure, double rotation, double tilt);
+void performPenHover(int screenId, double x, double y);
+void send_pen_input();
 void clearAllPressedEvents();
 bool setPrimaryDisplay(int displayIndex);
 
@@ -80,6 +82,19 @@ static std::recursive_mutex g_event_mutex;
 static std::unordered_map<uint16_t, KeyState> g_key_states;
 static uint16_t g_last_known_key_down = 0;
 static std::unordered_map<uint32_t, TouchState> g_touch_states;
+static std::chrono::steady_clock::time_point g_last_pen_event_time;
+constexpr auto PEN_REPEAT_INTERVAL = std::chrono::milliseconds(50);
+constexpr auto EDGE_TRIGGERED_POINTER_FLAGS =
+    POINTER_FLAG_DOWN | POINTER_FLAG_UP | POINTER_FLAG_CANCELED | POINTER_FLAG_UPDATE;
+
+static void clearPenEdgeTriggeredFlags() {
+    g_penInfo.penInfo.pointerInfo.pointerFlags &= ~EDGE_TRIGGERED_POINTER_FLAGS;
+}
+
+static bool hasActivePenPointer() {
+    return g_penDevice &&
+        g_penInfo.penInfo.pointerInfo.pointerFlags != POINTER_FLAG_NONE;
+}
 
 static void EventMonitorThread() {
     while (g_thread_running) {
@@ -110,6 +125,14 @@ static void EventMonitorThread() {
                             state.lastEventTime = now;
                         }
                     }
+                }
+
+                // Windows cancels synthetic pen hover/contact interactions if
+                // they are not refreshed, so keep the current pointer state alive.
+                if (hasActivePenPointer() &&
+                    now - g_last_pen_event_time >= PEN_REPEAT_INTERVAL) {
+                    send_pen_input();
+                    g_last_pen_event_time = now;
                 }
             }
         }
@@ -328,6 +351,8 @@ void destroyPenDevice() {
         fnDestroySyntheticPointerDevice(g_penDevice);
         g_penDevice = nullptr;
     }
+    g_penInfo = {};
+    g_last_pen_event_time = {};
 }
 
 bool sendTouchInput() {
@@ -587,9 +612,10 @@ void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButt
 
     send_pen_input();
 
-    // Clear edge-triggered flags after sending
-    constexpr auto EDGE_TRIGGERED_POINTER_FLAGS = POINTER_FLAG_DOWN | POINTER_FLAG_UP | POINTER_FLAG_CANCELED | POINTER_FLAG_UPDATE;
-    penInfo.pointerInfo.pointerFlags &= ~EDGE_TRIGGERED_POINTER_FLAGS;
+    // Clear edge-triggered flags after sending, leaving IN_RANGE/IN_CONTACT
+    // for the monitor thread to refresh while the pen remains active.
+    clearPenEdgeTriggeredFlags();
+    g_last_pen_event_time = std::chrono::steady_clock::now();
 }
 
 void performPenMove(int screenId, double x, double y, bool hasButton, double pressure, double rotation, double tilt) {
@@ -597,7 +623,10 @@ void performPenMove(int screenId, double x, double y, bool hasButton, double pre
         return;
     }
 
+    g_penInfo.type = PT_PEN;
     auto& penInfo = g_penInfo.penInfo;
+    penInfo.pointerInfo.pointerType = PT_PEN;
+    penInfo.pointerInfo.pointerId = 0;
 
     LONG out_x, out_y;
     if (!adjust_touch_to_screen(screenId, x, y, out_x, out_y)) return;
@@ -650,9 +679,42 @@ void performPenMove(int screenId, double x, double y, bool hasButton, double pre
 
     send_pen_input();
 
-    // Clear edge-triggered flags after sending
-    constexpr auto EDGE_TRIGGERED_POINTER_FLAGS = POINTER_FLAG_DOWN | POINTER_FLAG_UP | POINTER_FLAG_CANCELED | POINTER_FLAG_UPDATE;
-    penInfo.pointerInfo.pointerFlags &= ~EDGE_TRIGGERED_POINTER_FLAGS;
+    // Clear edge-triggered flags after sending, leaving IN_RANGE/IN_CONTACT
+    // for the monitor thread to refresh while the pen remains active.
+    clearPenEdgeTriggeredFlags();
+    g_last_pen_event_time = std::chrono::steady_clock::now();
+}
+
+void performPenHover(int screenId, double x, double y) {
+    if (!g_penDevice) {
+        if (!createPenDevice()) {
+            return;
+        }
+    }
+
+    g_penInfo.type = PT_PEN;
+    auto& penInfo = g_penInfo.penInfo;
+    penInfo.pointerInfo.pointerType = PT_PEN;
+    penInfo.pointerInfo.pointerId = 0;
+
+    LONG out_x, out_y;
+    if (!adjust_touch_to_screen(screenId, x, y, out_x, out_y)) return;
+    penInfo.pointerInfo.ptPixelLocation.x = out_x;
+    penInfo.pointerInfo.ptPixelLocation.y = out_y;
+
+    penInfo.pointerInfo.pointerFlags = POINTER_FLAG_INRANGE | POINTER_FLAG_UPDATE;
+    penInfo.penFlags &= ~(PEN_FLAG_BARREL | PEN_FLAG_ERASER);
+    penInfo.penMask = PEN_MASK_NONE;
+    penInfo.pressure = 0;
+    penInfo.rotation = 0;
+    penInfo.tiltX = 0;
+    penInfo.tiltY = 0;
+
+    send_pen_input();
+
+    // Keep IN_RANGE after the update edge is sent so hover can be refreshed.
+    clearPenEdgeTriggeredFlags();
+    g_last_pen_event_time = std::chrono::steady_clock::now();
 }
 
 BOOL IsRunningAsSystem() {
@@ -1033,15 +1095,15 @@ void clearAllPressedEvents() {
     }
     g_touch_states.clear();
     
-    // Clear pen device if it exists and is in contact
-    if (g_penDevice && (g_penInfo.penInfo.pointerInfo.pointerFlags & POINTER_FLAG_INCONTACT)) {
-        // Send pen up event to clear the state
-        g_penInfo.penInfo.pointerInfo.pointerFlags &= ~(POINTER_FLAG_INCONTACT | POINTER_FLAG_INRANGE);
-        g_penInfo.penInfo.pointerInfo.pointerFlags |= POINTER_FLAG_UP;
+    // Clear pen device if it has an active hover or contact state.
+    if (hasActivePenPointer()) {
+        auto& penFlags = g_penInfo.penInfo.pointerInfo.pointerFlags;
+        const bool wasInContact = (penFlags & POINTER_FLAG_INCONTACT) != 0;
+        penFlags &= ~(POINTER_FLAG_INCONTACT | POINTER_FLAG_INRANGE);
+        penFlags |= wasInContact ? POINTER_FLAG_UP : POINTER_FLAG_UPDATE;
         send_pen_input();
-        // Clear edge-triggered flags
-        constexpr auto EDGE_TRIGGERED_POINTER_FLAGS = POINTER_FLAG_DOWN | POINTER_FLAG_UP | POINTER_FLAG_CANCELED | POINTER_FLAG_UPDATE;
-        g_penInfo.penInfo.pointerInfo.pointerFlags &= ~EDGE_TRIGGERED_POINTER_FLAGS;
+        clearPenEdgeTriggeredFlags();
+        g_last_pen_event_time = {};
     }
     
     // Clear mouse buttons (left and right)
@@ -1427,6 +1489,16 @@ void HardwareSimulatorPlugin::HandleMethodCall(
             static_cast<double>(std::get<double>((pressure))),
             static_cast<double>(std::get<double>((rotation))),
             static_cast<double>(std::get<double>((tilt)))
+        );
+        result->Success(nullptr);
+  } else if (method_call.method_name().compare("penHover") == 0) {
+        auto screenId = (args->find(flutter::EncodableValue("screenId")))->second;
+        auto x = (args->find(flutter::EncodableValue("x")))->second;
+        auto y = (args->find(flutter::EncodableValue("y")))->second;
+        performPenHover(
+            static_cast<int>(std::get<int>((screenId))),
+            static_cast<double>(std::get<double>((x))),
+            static_cast<double>(std::get<double>((y)))
         );
         result->Success(nullptr);
   } else if (method_call.method_name().compare("clearAllPressedEvents") == 0) {

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <sstream>
 
 // Used to run win32 service.
@@ -581,7 +582,7 @@ void performTouchMove(int screenId, double x, double y, uint32_t touchId) {
 }
 
 void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButton, double pressure, double rotation, double tilt) {
-    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+    std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
 
     if (!g_penDevice) {
         if (!createPenDevice()) {
@@ -658,10 +659,12 @@ void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButt
     // for the monitor thread to refresh while the pen remains active.
     clearPenEdgeTriggeredFlags();
     recordPenInputAfterSend();
+    lock.unlock();
+    CursorMonitor::syncNow();
 }
 
 void performPenMove(int screenId, double x, double y, bool hasButton, double pressure, double rotation, double tilt) {
-    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+    std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
 
     if (!g_penDevice) {
         return;
@@ -727,10 +730,12 @@ void performPenMove(int screenId, double x, double y, bool hasButton, double pre
     // for the monitor thread to refresh while the pen remains active.
     clearPenEdgeTriggeredFlags();
     recordPenInputAfterSend();
+    lock.unlock();
+    CursorMonitor::syncNow();
 }
 
 void performPenHover(int screenId, double x, double y) {
-    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+    std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
 
     if (!g_penDevice) {
         if (!createPenDevice()) {
@@ -761,6 +766,8 @@ void performPenHover(int screenId, double x, double y) {
     // Keep IN_RANGE after the update edge is sent so hover can be refreshed.
     clearPenEdgeTriggeredFlags();
     recordPenInputAfterSend();
+    lock.unlock();
+    CursorMonitor::syncNow();
 }
 
 BOOL IsRunningAsSystem() {
@@ -1122,7 +1129,8 @@ void performKeyEvent(uint16_t modcode, bool isDown, bool isRepeat = false) {
 }
 
 void clearAllPressedEvents() {
-    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+    std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
+    bool shouldSyncCursor = false;
     
     // Clear all pressed keyboard keys
     for (auto& [keyCode, state] : g_key_states) {
@@ -1144,6 +1152,7 @@ void clearAllPressedEvents() {
     // Clear pen device if it has an active hover or contact state.
     if (hasActivePenPointer()) {
         clearActivePenPointer();
+        shouldSyncCursor = true;
     }
     
     // Clear mouse buttons (left and right)
@@ -1162,6 +1171,11 @@ void clearAllPressedEvents() {
     }
     if (GetAsyncKeyState(VK_XBUTTON2) & 0x8000) {
         performMouseButton(5, true); // XButton2 up
+    }
+
+    lock.unlock();
+    if (shouldSyncCursor) {
+        CursorMonitor::syncNow();
     }
 }
 

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -541,6 +541,8 @@ void performTouchMove(int screenId, double x, double y, uint32_t touchId) {
 }
 
 void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButton, double pressure, double rotation, double tilt) {
+    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+
     if (!g_penDevice) {
         if (!createPenDevice()) {
             return;
@@ -619,6 +621,8 @@ void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButt
 }
 
 void performPenMove(int screenId, double x, double y, bool hasButton, double pressure, double rotation, double tilt) {
+    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+
     if (!g_penDevice) {
         return;
     }
@@ -686,6 +690,8 @@ void performPenMove(int screenId, double x, double y, bool hasButton, double pre
 }
 
 void performPenHover(int screenId, double x, double y) {
+    std::lock_guard<std::recursive_mutex> lock(g_event_mutex);
+
     if (!g_penDevice) {
         if (!createPenDevice()) {
             return;

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -82,8 +82,10 @@ static std::recursive_mutex g_event_mutex;
 static std::unordered_map<uint16_t, KeyState> g_key_states;
 static uint16_t g_last_known_key_down = 0;
 static std::unordered_map<uint32_t, TouchState> g_touch_states;
-static std::chrono::steady_clock::time_point g_last_pen_event_time;
+static std::chrono::steady_clock::time_point g_last_pen_input_time;
+static std::chrono::steady_clock::time_point g_last_pen_refresh_time;
 constexpr auto PEN_REPEAT_INTERVAL = std::chrono::milliseconds(50);
+constexpr auto PEN_HOVER_IDLE_TIMEOUT = std::chrono::milliseconds(250);
 constexpr auto EDGE_TRIGGERED_POINTER_FLAGS =
     POINTER_FLAG_DOWN | POINTER_FLAG_UP | POINTER_FLAG_CANCELED | POINTER_FLAG_UPDATE;
 
@@ -94,6 +96,39 @@ static void clearPenEdgeTriggeredFlags() {
 static bool hasActivePenPointer() {
     return g_penDevice &&
         g_penInfo.penInfo.pointerInfo.pointerFlags != POINTER_FLAG_NONE;
+}
+
+static bool hasHoverOnlyPenPointer() {
+    auto flags = g_penInfo.penInfo.pointerInfo.pointerFlags;
+    return (flags & POINTER_FLAG_INRANGE) != 0 &&
+        (flags & POINTER_FLAG_INCONTACT) == 0;
+}
+
+static void clearActivePenPointer() {
+    if (!hasActivePenPointer()) {
+        return;
+    }
+
+    auto& penFlags = g_penInfo.penInfo.pointerInfo.pointerFlags;
+    const bool wasInContact = (penFlags & POINTER_FLAG_INCONTACT) != 0;
+    penFlags &= ~(POINTER_FLAG_INCONTACT | POINTER_FLAG_INRANGE);
+    penFlags |= wasInContact ? POINTER_FLAG_UP : POINTER_FLAG_UPDATE;
+    send_pen_input();
+    clearPenEdgeTriggeredFlags();
+    g_last_pen_input_time = {};
+    g_last_pen_refresh_time = {};
+}
+
+static void recordPenInputAfterSend() {
+    if (!hasActivePenPointer()) {
+        g_last_pen_input_time = {};
+        g_last_pen_refresh_time = {};
+        return;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    g_last_pen_input_time = now;
+    g_last_pen_refresh_time = now;
 }
 
 static void EventMonitorThread() {
@@ -127,12 +162,16 @@ static void EventMonitorThread() {
                     }
                 }
 
-                // Windows cancels synthetic pen hover/contact interactions if
-                // they are not refreshed, so keep the current pointer state alive.
-                if (hasActivePenPointer() &&
-                    now - g_last_pen_event_time >= PEN_REPEAT_INTERVAL) {
-                    send_pen_input();
-                    g_last_pen_event_time = now;
+                if (hasActivePenPointer()) {
+                    // Keep the current pointer state alive, but do not keep a
+                    // stale hover alive forever after the real pen leaves range.
+                    if (hasHoverOnlyPenPointer() &&
+                        now - g_last_pen_input_time >= PEN_HOVER_IDLE_TIMEOUT) {
+                        clearActivePenPointer();
+                    } else if (now - g_last_pen_refresh_time >= PEN_REPEAT_INTERVAL) {
+                        send_pen_input();
+                        g_last_pen_refresh_time = now;
+                    }
                 }
             }
         }
@@ -352,7 +391,8 @@ void destroyPenDevice() {
         g_penDevice = nullptr;
     }
     g_penInfo = {};
-    g_last_pen_event_time = {};
+    g_last_pen_input_time = {};
+    g_last_pen_refresh_time = {};
 }
 
 bool sendTouchInput() {
@@ -617,7 +657,7 @@ void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButt
     // Clear edge-triggered flags after sending, leaving IN_RANGE/IN_CONTACT
     // for the monitor thread to refresh while the pen remains active.
     clearPenEdgeTriggeredFlags();
-    g_last_pen_event_time = std::chrono::steady_clock::now();
+    recordPenInputAfterSend();
 }
 
 void performPenMove(int screenId, double x, double y, bool hasButton, double pressure, double rotation, double tilt) {
@@ -686,7 +726,7 @@ void performPenMove(int screenId, double x, double y, bool hasButton, double pre
     // Clear edge-triggered flags after sending, leaving IN_RANGE/IN_CONTACT
     // for the monitor thread to refresh while the pen remains active.
     clearPenEdgeTriggeredFlags();
-    g_last_pen_event_time = std::chrono::steady_clock::now();
+    recordPenInputAfterSend();
 }
 
 void performPenHover(int screenId, double x, double y) {
@@ -720,7 +760,7 @@ void performPenHover(int screenId, double x, double y) {
 
     // Keep IN_RANGE after the update edge is sent so hover can be refreshed.
     clearPenEdgeTriggeredFlags();
-    g_last_pen_event_time = std::chrono::steady_clock::now();
+    recordPenInputAfterSend();
 }
 
 BOOL IsRunningAsSystem() {
@@ -1103,13 +1143,7 @@ void clearAllPressedEvents() {
     
     // Clear pen device if it has an active hover or contact state.
     if (hasActivePenPointer()) {
-        auto& penFlags = g_penInfo.penInfo.pointerInfo.pointerFlags;
-        const bool wasInContact = (penFlags & POINTER_FLAG_INCONTACT) != 0;
-        penFlags &= ~(POINTER_FLAG_INCONTACT | POINTER_FLAG_INRANGE);
-        penFlags |= wasInContact ? POINTER_FLAG_UP : POINTER_FLAG_UPDATE;
-        send_pen_input();
-        clearPenEdgeTriggeredFlags();
-        g_last_pen_event_time = {};
+        clearActivePenPointer();
     }
     
     // Clear mouse buttons (left and right)


### PR DESCRIPTION
## Summary
- add a Dart/MethodChannel API for native pen hover injection
- inject Windows synthetic pen hover as an in-range, non-contact pointer update
- keep active pen hover/contact alive so Windows does not cancel the synthetic pointer state

## Validation
- `dart format lib test`
- `dart analyze lib test` (passes with existing `print` infos in platform_interface)
- `flutter test`
- main app `flutter analyze`
- main app targeted remote_desktop tests
- main app `flutter build windows --release`

Dependent main repo wiring PR follows after this submodule PR.