### PR TITLE
feat(windows): add text focus listener

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,6 +37,8 @@ class SimulatorScreen extends StatefulWidget {
 }
 
 class _SimulatorScreenState extends State<SimulatorScreen> {
+  static const int _textFocusCallbackId = 3;
+
   final TextEditingController xController = TextEditingController();
   final TextEditingController yController = TextEditingController();
   final TextEditingController relXController = TextEditingController();
@@ -200,6 +202,8 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
 
   // 鼠标位置监控相关变量
   bool _positionMonitoringActive = false;
+  bool _textFocusMonitoringActive = false;
+  final List<FocusedTextInput> _recentTextFocuses = [];
 
   void _startPositionMonitoring() async {
     if (_positionMonitoringActive) return;
@@ -224,6 +228,28 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
     print('鼠标位置监控已停止');
   }
 
+  void _startTextFocusMonitoring({bool notify = true}) {
+    if (!Platform.isWindows || _textFocusMonitoringActive) return;
+    _textFocusMonitoringActive = true;
+    HardwareSimulator.addTextInputFocusChanged((FocusedTextInput info) {
+      if (!mounted) return;
+      setState(() {
+        _recentTextFocuses.insert(0, info);
+        if (_recentTextFocuses.length > 3) {
+          _recentTextFocuses.removeRange(3, _recentTextFocuses.length);
+        }
+      });
+    }, _textFocusCallbackId);
+    if (notify) setState(() {});
+  }
+
+  void _stopTextFocusMonitoring({bool notify = true}) {
+    if (!Platform.isWindows || !_textFocusMonitoringActive) return;
+    HardwareSimulator.removeTextInputFocusChanged(_textFocusCallbackId);
+    _textFocusMonitoringActive = false;
+    if (notify) setState(() {});
+  }
+
   FocusNode? _textFieldFocusNode;
 
   @override
@@ -233,6 +259,7 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
     //HardwareKeyboard.instance.addHandler(_handleKeyEvent);
     _textFieldFocusNode = FocusNode();
     _registerTrackCursor(); // 注册trackCursor回调
+    _startTextFocusMonitoring(notify: false);
   }
 
   @override
@@ -242,6 +269,7 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
     _unregisterCursorChanged();
     _unregisterTrackCursor(); // 注销trackCursor回调
     _stopPositionMonitoring(); // 停止鼠标位置监控
+    _stopTextFocusMonitoring(notify: false);
     super.dispose();
   }
 
@@ -381,6 +409,8 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
             ),
           ),
         SizedBox(height: 20),
+        if (Platform.isWindows) _buildTextFocusPanel(),
+        if (Platform.isWindows) SizedBox(height: 20),
         // First Row: Absolute Mouse Move
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -640,6 +670,79 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
           ],
         ),
       ],
+    );
+  }
+
+  Widget _buildTextFocusPanel() {
+    return Container(
+      width: double.infinity,
+      margin: EdgeInsets.symmetric(horizontal: 16),
+      padding: EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.blueGrey.shade200),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Windows 文本焦点监听（最近 3 条）',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+              ),
+              ElevatedButton(
+                onPressed: _textFocusMonitoringActive
+                    ? null
+                    : _startTextFocusMonitoring,
+                child: Text('开始监听'),
+              ),
+              SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: _textFocusMonitoringActive
+                    ? _stopTextFocusMonitoring
+                    : null,
+                child: Text('停止监听'),
+              ),
+            ],
+          ),
+          SizedBox(height: 8),
+          if (_recentTextFocuses.isEmpty)
+            Text('还没有捕获到文本框焦点。请切到任意应用并 focus 文本输入框。')
+          else
+            ..._recentTextFocuses.map(_buildTextFocusRow),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextFocusRow(FocusedTextInput info) {
+    final time = DateTime.fromMillisecondsSinceEpoch(info.timestampMs);
+    final hh = time.hour.toString().padLeft(2, '0');
+    final mm = time.minute.toString().padLeft(2, '0');
+    final ss = time.second.toString().padLeft(2, '0');
+    final flags = [
+      if (info.isPassword) 'password',
+      if (info.isReadOnly) 'UIA-readOnly',
+      if (info.supportsTextPattern) 'TextPattern',
+      if (info.supportsValuePattern) 'ValuePattern',
+      if (info.supportsTextEditPattern) 'TextEditPattern',
+      if (info.hasActiveTextCaret) 'activeCaret',
+    ].join(', ');
+
+    return Padding(
+      padding: EdgeInsets.only(top: 6),
+      child: Text(
+        '[$hh:$mm:$ss] ${info.displayName} | '
+        'type=${info.localizedControlType.isEmpty ? info.controlTypeId : info.localizedControlType} '
+        'class=${info.className.isEmpty ? "-" : info.className} '
+        'proc=${info.processName.isEmpty ? info.processId : info.processName}'
+        '${flags.isEmpty ? "" : " | $flags"}',
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
     );
   }
 }

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -7,16 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <hardware_simulator/hardware_simulator_plugin.h>
-#include <pointer_lock/pointer_lock_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) hardware_simulator_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "HardwareSimulatorPlugin");
   hardware_simulator_plugin_register_with_registrar(hardware_simulator_registrar);
-  g_autoptr(FlPluginRegistrar) pointer_lock_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PointerLockPlugin");
-  pointer_lock_plugin_register_with_registrar(pointer_lock_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   hardware_simulator
-  pointer_lock
   url_launcher_linux
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import hardware_simulator
-import pointer_lock
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   HardwareSimulatorPlugin.register(with: registry.registrar(forPlugin: "HardwareSimulatorPlugin"))
-  PointerLockPlugin.register(with: registry.registrar(forPlugin: "PointerLockPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,14 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <hardware_simulator/hardware_simulator_plugin_c_api.h>
-#include <pointer_lock/pointer_lock_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   HardwareSimulatorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("HardwareSimulatorPluginCApi"));
-  PointerLockPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PointerLockPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   hardware_simulator
-  pointer_lock
   url_launcher_windows
 )
 

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -1,6 +1,9 @@
 import 'hardware_simulator_platform_interface.dart';
 export 'hardware_simulator_platform_interface.dart'
-    show DisplayCountChangedCallback;
+    show
+        DisplayCountChangedCallback,
+        FocusedTextInput,
+        TextInputFocusChangedCallback;
 import 'display_data.dart';
 
 /// Snapshot of the macOS TCC permissions relevant to remote-control hosting.
@@ -251,6 +254,16 @@ class HardwareSimulator {
   static void removeDisplayCountChangedCallback(int callbackId) {
     HardwareSimulatorPlatform.instance
         .removeDisplayCountChangedCallback(callbackId);
+  }
+
+  static void addTextInputFocusChanged(
+      TextInputFocusChangedCallback callback, int callbackId) {
+    HardwareSimulatorPlatform.instance
+        .addTextInputFocusChanged(callback, callbackId);
+  }
+
+  static void removeTextInputFocusChanged(int callbackId) {
+    HardwareSimulatorPlatform.instance.removeTextInputFocusChanged(callbackId);
   }
 
   HWKeyboard getKeyboard() {

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -61,6 +61,12 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
         if (displayCountCallbacks.containsKey(callbackID)) {
           displayCountCallbacks[callbackID]!(call.arguments['displayCount']);
         }
+      } else if (call.method == "onTextInputFocusChanged") {
+        int callbackID = call.arguments['callbackID'];
+        if (textInputFocusCallbacks.containsKey(callbackID)) {
+          textInputFocusCallbacks[callbackID]!(
+              FocusedTextInput.fromMap(call.arguments));
+        }
       }
       return null;
     });
@@ -235,6 +241,7 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   final Map<int, CursorImageUpdatedCallback> cursorImageCallbacks = {};
   final Map<int, CursorPositionUpdatedCallback> cursorPositionCallbacks = {};
   final Map<int, DisplayCountChangedCallback> displayCountCallbacks = {};
+  final Map<int, TextInputFocusChangedCallback> textInputFocusCallbacks = {};
 
   @override
   void addCursorImageUpdated(
@@ -305,6 +312,32 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
       displayCountCallbacks.remove(callbackId);
     }
     methodChannel.invokeMethod('removeDisplayCountChangedCallback', {
+      'callbackID': callbackId,
+    });
+  }
+
+  @override
+  void addTextInputFocusChanged(
+      TextInputFocusChangedCallback callback, int callbackId) {
+    if (kIsWeb || !Platform.isWindows) {
+      return;
+    }
+    if (!isinitialized) init();
+    textInputFocusCallbacks[callbackId] = callback;
+    methodChannel.invokeMethod('hookTextInputFocusChanged', {
+      'callbackID': callbackId,
+    });
+  }
+
+  @override
+  void removeTextInputFocusChanged(int callbackId) {
+    if (textInputFocusCallbacks.containsKey(callbackId)) {
+      textInputFocusCallbacks.remove(callbackId);
+    }
+    if (kIsWeb || !Platform.isWindows) {
+      return;
+    }
+    methodChannel.invokeMethod('unhookTextInputFocusChanged', {
       'callbackID': callbackId,
     });
   }

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -16,6 +16,77 @@ typedef CursorImageUpdatedCallback = void Function(
 typedef CursorPositionUpdatedCallback = void Function(
     int message, int screenId, double xPercent, double yPercent);
 typedef DisplayCountChangedCallback = void Function(int displayCount);
+typedef TextInputFocusChangedCallback = void Function(FocusedTextInput info);
+
+class FocusedTextInput {
+  final String name;
+  final String localizedControlType;
+  final String className;
+  final String automationId;
+  final String processName;
+  final int controlTypeId;
+  final int processId;
+  final int nativeWindowHandle;
+  final bool isPassword;
+
+  /// Raw UIA `ValuePattern.IsReadOnly`.
+  ///
+  /// Some rich editors, notably Microsoft Word's document surface, report this
+  /// as true even while the user can type into the active document.
+  final bool isReadOnly;
+  final bool supportsTextPattern;
+  final bool supportsValuePattern;
+  final bool supportsTextEditPattern;
+  final bool hasActiveTextCaret;
+  final int timestampMs;
+
+  const FocusedTextInput({
+    required this.name,
+    required this.localizedControlType,
+    required this.className,
+    required this.automationId,
+    required this.processName,
+    required this.controlTypeId,
+    required this.processId,
+    required this.nativeWindowHandle,
+    required this.isPassword,
+    required this.isReadOnly,
+    required this.supportsTextPattern,
+    required this.supportsValuePattern,
+    required this.supportsTextEditPattern,
+    required this.hasActiveTextCaret,
+    required this.timestampMs,
+  });
+
+  factory FocusedTextInput.fromMap(Map<dynamic, dynamic> map) {
+    return FocusedTextInput(
+      name: map['name']?.toString() ?? '',
+      localizedControlType: map['localizedControlType']?.toString() ?? '',
+      className: map['className']?.toString() ?? '',
+      automationId: map['automationId']?.toString() ?? '',
+      processName: map['processName']?.toString() ?? '',
+      controlTypeId: (map['controlTypeId'] as num?)?.toInt() ?? 0,
+      processId: (map['processId'] as num?)?.toInt() ?? 0,
+      nativeWindowHandle: (map['nativeWindowHandle'] as num?)?.toInt() ?? 0,
+      isPassword: map['isPassword'] == true,
+      isReadOnly: map['isReadOnly'] == true,
+      supportsTextPattern: map['supportsTextPattern'] == true,
+      supportsValuePattern: map['supportsValuePattern'] == true,
+      supportsTextEditPattern: map['supportsTextEditPattern'] == true,
+      hasActiveTextCaret: map['hasActiveTextCaret'] == true,
+      timestampMs: (map['timestampMs'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  String get displayName {
+    if (name.trim().isNotEmpty) return name.trim();
+    if (automationId.trim().isNotEmpty) return '#${automationId.trim()}';
+    if (className.trim().isNotEmpty) return className.trim();
+    return localizedControlType.trim().isNotEmpty
+        ? localizedControlType.trim()
+        : 'Text input';
+  }
+}
 
 abstract class HardwareSimulatorPlatform extends PlatformInterface {
   /// Constructs a HardwareSimulatorPlatform.
@@ -177,6 +248,17 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   void removeDisplayCountChangedCallback(int callbackId) {
     throw UnimplementedError(
         'removeDisplayCountChangedCallback() has not been implemented.');
+  }
+
+  void addTextInputFocusChanged(
+      TextInputFocusChangedCallback callback, int callbackId) {
+    throw UnimplementedError(
+        'addTextInputFocusChanged() has not been implemented.');
+  }
+
+  void removeTextInputFocusChanged(int callbackId) {
+    throw UnimplementedError(
+        'removeTextInputFocusChanged() has not been implemented.');
   }
 
   Future<void> performKeyEvent(int keyCode, bool isDown) async {

--- a/lib/hardware_simulator_web.dart
+++ b/lib/hardware_simulator_web.dart
@@ -151,4 +151,11 @@ class HardwareSimulatorPluginWeb extends HardwareSimulatorPlatform {
   void removeCursorWheel(CursorWheelCallback callback) {
     cursorWheelCallbacks.remove(callback);
   }
+
+  @override
+  void addTextInputFocusChanged(
+      TextInputFocusChangedCallback callback, int callbackId) {}
+
+  @override
+  void removeTextInputFocusChanged(int callbackId) {}
 }

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -28,6 +28,8 @@ list(APPEND PLUGIN_SOURCES
   "gamecontroller_manager.h"
   "notification_window.cc"
   "notification_window.h"
+  "text_focus_monitor.cc"
+  "text_focus_monitor.h"
   "virtual_display.cc"
   "virtual_display.h"
   "virtual_display_control.cc"
@@ -70,6 +72,9 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin
   "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/vigembus/lib/x64/ViGEmClient.lib"
   setupapi
   cfgmgr32
+  ole32
+  oleaut32
+  uiautomationcore
   user32)
 
 # List of absolute paths to libraries that should be bundled with the plugin.

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -4,6 +4,7 @@
 #include "desktop_service_input_client.h"
 #include "gamecontroller_manager.h"
 #include "notification_window.h"
+#include "text_focus_monitor.h"
 #include "virtual_display_control.h"
 #include "SmartKeyboardBlocker.h"
 
@@ -991,6 +992,7 @@ HardwareSimulatorPlugin::HardwareSimulatorPlugin() {
 
 HardwareSimulatorPlugin::~HardwareSimulatorPlugin() {
     DesktopServiceInputClient::Instance().Close();
+    TextFocusMonitor::StopAll();
     StopMonitorThread();
     destroyTouchDevice();
     destroyPenDevice();
@@ -1435,6 +1437,36 @@ void HardwareSimulatorPlugin::HandleMethodCall(
   } else if (method_call.method_name().compare("removeDisplayCountChangedCallback") == 0) {
         auto callbackID = static_cast<int>(std::get<int>((args->find(flutter::EncodableValue("callbackID")))->second));
         removeDisplayCountChangedCallback(callbackID);
+        result->Success(nullptr);
+  } else if (method_call.method_name().compare("hookTextInputFocusChanged") == 0) {
+        auto callbackID = static_cast<int>(std::get<int>((args->find(flutter::EncodableValue("callbackID")))->second));
+        TextFocusMonitor::Start([this, callbackID](const TextFocusInfo& info) {
+            flutter::EncodableMap encoded_message;
+            encoded_message[flutter::EncodableValue("callbackID")] = flutter::EncodableValue(callbackID);
+            encoded_message[flutter::EncodableValue("name")] = flutter::EncodableValue(info.name);
+            encoded_message[flutter::EncodableValue("localizedControlType")] = flutter::EncodableValue(info.localized_control_type);
+            encoded_message[flutter::EncodableValue("className")] = flutter::EncodableValue(info.class_name);
+            encoded_message[flutter::EncodableValue("automationId")] = flutter::EncodableValue(info.automation_id);
+            encoded_message[flutter::EncodableValue("processName")] = flutter::EncodableValue(info.process_name);
+            encoded_message[flutter::EncodableValue("controlTypeId")] = flutter::EncodableValue(info.control_type_id);
+            encoded_message[flutter::EncodableValue("processId")] = flutter::EncodableValue(info.process_id);
+            encoded_message[flutter::EncodableValue("nativeWindowHandle")] = flutter::EncodableValue(info.native_window_handle);
+            encoded_message[flutter::EncodableValue("isPassword")] = flutter::EncodableValue(info.is_password);
+            encoded_message[flutter::EncodableValue("isReadOnly")] = flutter::EncodableValue(info.is_read_only);
+            encoded_message[flutter::EncodableValue("supportsTextPattern")] = flutter::EncodableValue(info.supports_text_pattern);
+            encoded_message[flutter::EncodableValue("supportsValuePattern")] = flutter::EncodableValue(info.supports_value_pattern);
+            encoded_message[flutter::EncodableValue("supportsTextEditPattern")] = flutter::EncodableValue(info.supports_text_edit_pattern);
+            encoded_message[flutter::EncodableValue("hasActiveTextCaret")] = flutter::EncodableValue(info.has_active_text_caret);
+            encoded_message[flutter::EncodableValue("timestampMs")] = flutter::EncodableValue(info.timestamp_ms);
+            if (channel_) {
+                channel_->InvokeMethod("onTextInputFocusChanged",
+                    std::make_unique<flutter::EncodableValue>(encoded_message));
+            }
+        }, callbackID);
+        result->Success(nullptr);
+  } else if (method_call.method_name().compare("unhookTextInputFocusChanged") == 0) {
+        auto callbackID = static_cast<int>(std::get<int>((args->find(flutter::EncodableValue("callbackID")))->second));
+        TextFocusMonitor::Stop(callbackID);
         result->Success(nullptr);
   } else if (method_call.method_name().compare("createGameController") == 0) {
         int hr = GameControllerManager::CreateGameController();

--- a/windows/text_focus_monitor.cc
+++ b/windows/text_focus_monitor.cc
@@ -1,0 +1,600 @@
+#include "text_focus_monitor.h"
+
+#include <UIAutomation.h>
+#include <windows.h>
+
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace hardware_simulator {
+namespace {
+
+std::mutex g_mutex;
+std::map<int, TextFocusMonitor::Callback> g_callbacks;
+std::thread g_worker;
+HANDLE g_stop_event = nullptr;
+bool g_running = false;
+
+std::mutex g_pointer_mutex;
+std::optional<POINT> g_last_pointer_pos;
+ULONGLONG g_last_pointer_tick_ms = 0;
+constexpr ULONGLONG kPointerFocusWindowMs = 1200;
+constexpr LONG kPointerHitTolerancePx = 8;
+constexpr UINT kInspectPointerClickMessage = WM_APP + 218;
+DWORD g_worker_thread_id = 0;
+
+std::mutex g_notify_mutex;
+std::string g_last_notify_key;
+ULONGLONG g_last_notify_tick_ms = 0;
+constexpr ULONGLONG kDuplicateNotifyWindowMs = 350;
+
+std::string WideToUtf8(const wchar_t* value, int length) {
+  if (value == nullptr || length <= 0) {
+    return "";
+  }
+  const int size =
+      WideCharToMultiByte(CP_UTF8, 0, value, length, nullptr, 0, nullptr,
+                          nullptr);
+  if (size <= 0) {
+    return "";
+  }
+  std::string output(size, '\0');
+  WideCharToMultiByte(CP_UTF8, 0, value, length, output.data(), size, nullptr,
+                      nullptr);
+  return output;
+}
+
+std::string BstrToUtf8(BSTR value) {
+  if (value == nullptr) {
+    return "";
+  }
+  return WideToUtf8(value, static_cast<int>(SysStringLen(value)));
+}
+
+std::string ToLowerAscii(std::string value) {
+  for (auto& ch : value) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return value;
+}
+
+std::string ProcessNameFromPid(int process_id) {
+  if (process_id <= 0) {
+    return "";
+  }
+
+  HANDLE process =
+      OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id);
+  if (process == nullptr) {
+    return "";
+  }
+
+  wchar_t path[MAX_PATH] = {};
+  DWORD length = MAX_PATH;
+  std::string result;
+  if (QueryFullProcessImageNameW(process, 0, path, &length) && length > 0) {
+    std::wstring full_path(path, length);
+    const auto pos = full_path.find_last_of(L"\\/");
+    const std::wstring name =
+        pos == std::wstring::npos ? full_path : full_path.substr(pos + 1);
+    result = WideToUtf8(name.c_str(), static_cast<int>(name.size()));
+  }
+
+  CloseHandle(process);
+  return result;
+}
+
+std::string GetBstrProperty(
+    IUIAutomationElement* element,
+    HRESULT (__stdcall IUIAutomationElement::*getter)(BSTR*)) {
+  BSTR value = nullptr;
+  if (FAILED((element->*getter)(&value)) || value == nullptr) {
+    return "";
+  }
+  std::string result = BstrToUtf8(value);
+  SysFreeString(value);
+  return result;
+}
+
+bool GetBoolProperty(IUIAutomationElement* element, PROPERTYID property_id,
+                     bool fallback = false) {
+  VARIANT value;
+  VariantInit(&value);
+  bool result = fallback;
+  if (SUCCEEDED(element->GetCurrentPropertyValue(property_id, &value)) &&
+      value.vt == VT_BOOL) {
+    result = value.boolVal == VARIANT_TRUE;
+  }
+  VariantClear(&value);
+  return result;
+}
+
+std::string ControlTypeName(CONTROLTYPEID control_type) {
+  switch (control_type) {
+    case UIA_EditControlTypeId:
+      return "Edit";
+    case UIA_DocumentControlTypeId:
+      return "Document";
+    case UIA_ComboBoxControlTypeId:
+      return "ComboBox";
+    case UIA_PaneControlTypeId:
+      return "Pane";
+    case UIA_CustomControlTypeId:
+      return "Custom";
+    default:
+      return "";
+  }
+}
+
+bool IsKnownRichTextEditor(const std::string& process_name) {
+  const auto lower = ToLowerAscii(process_name);
+  return lower == "winword.exe";
+}
+
+bool HasActiveTextCaret(IUIAutomationElement* element) {
+  IUnknown* pattern_unknown = nullptr;
+  if (FAILED(element->GetCurrentPattern(UIA_TextPattern2Id,
+                                        &pattern_unknown)) ||
+      pattern_unknown == nullptr) {
+    return false;
+  }
+
+  IUIAutomationTextPattern2* pattern = nullptr;
+  if (FAILED(pattern_unknown->QueryInterface(IID_PPV_ARGS(&pattern))) ||
+      pattern == nullptr) {
+    pattern_unknown->Release();
+    return false;
+  }
+  pattern_unknown->Release();
+
+  BOOL is_active = FALSE;
+  IUIAutomationTextRange* range = nullptr;
+  const HRESULT hr = pattern->GetCaretRange(&is_active, &range);
+  if (range != nullptr) {
+    range->Release();
+  }
+  pattern->Release();
+  return SUCCEEDED(hr) && is_active == TRUE;
+}
+
+bool IsLikelyTextInput(CONTROLTYPEID control_type, bool supports_text_pattern,
+                       bool supports_value_pattern,
+                       bool supports_text_edit_pattern,
+                       bool has_active_text_caret,
+                       const std::string& process_name) {
+  if (control_type == UIA_EditControlTypeId) {
+    return true;
+  }
+  if (control_type == UIA_ComboBoxControlTypeId && supports_value_pattern) {
+    return true;
+  }
+  if (control_type == UIA_DocumentControlTypeId) {
+    return has_active_text_caret ||
+           (supports_text_pattern && IsKnownRichTextEditor(process_name));
+  }
+  if (supports_text_edit_pattern || has_active_text_caret) {
+    return true;
+  }
+  return false;
+}
+
+bool RectContainsPointWithTolerance(const RECT& rect, const POINT& point) {
+  if (rect.right <= rect.left || rect.bottom <= rect.top) {
+    return false;
+  }
+  return point.x >= rect.left - kPointerHitTolerancePx &&
+         point.x <= rect.right + kPointerHitTolerancePx &&
+         point.y >= rect.top - kPointerHitTolerancePx &&
+         point.y <= rect.bottom + kPointerHitTolerancePx;
+}
+
+bool WasFocusedByRecentPointerClick(IUIAutomationElement* element) {
+  POINT pointer_pos = {};
+  ULONGLONG pointer_tick_ms = 0;
+  {
+    std::lock_guard<std::mutex> lock(g_pointer_mutex);
+    if (!g_last_pointer_pos.has_value()) {
+      return false;
+    }
+    pointer_pos = g_last_pointer_pos.value();
+    pointer_tick_ms = g_last_pointer_tick_ms;
+  }
+
+  if (GetTickCount64() - pointer_tick_ms > kPointerFocusWindowMs) {
+    return false;
+  }
+
+  RECT bounding_rect = {};
+  if (FAILED(element->get_CurrentBoundingRectangle(&bounding_rect))) {
+    return false;
+  }
+  return RectContainsPointWithTolerance(bounding_rect, pointer_pos);
+}
+
+std::optional<TextFocusInfo> BuildTextFocusInfo(
+    IUIAutomationElement* element,
+    const std::optional<POINT>& pointer_hit = std::nullopt) {
+  if (element == nullptr) {
+    return std::nullopt;
+  }
+
+  BOOL is_enabled = FALSE;
+  if (SUCCEEDED(element->get_CurrentIsEnabled(&is_enabled)) && !is_enabled) {
+    return std::nullopt;
+  }
+
+  BOOL is_keyboard_focusable = TRUE;
+  if (SUCCEEDED(element->get_CurrentIsKeyboardFocusable(
+          &is_keyboard_focusable)) &&
+      !is_keyboard_focusable) {
+    return std::nullopt;
+  }
+
+  CONTROLTYPEID control_type = 0;
+  if (FAILED(element->get_CurrentControlType(&control_type))) {
+    return std::nullopt;
+  }
+
+  int process_id = 0;
+  element->get_CurrentProcessId(&process_id);
+  const auto process_name = ProcessNameFromPid(process_id);
+
+  const bool supports_text_pattern =
+      GetBoolProperty(element, UIA_IsTextPatternAvailablePropertyId);
+  const bool supports_value_pattern =
+      GetBoolProperty(element, UIA_IsValuePatternAvailablePropertyId);
+  const bool supports_text_edit_pattern =
+      GetBoolProperty(element, UIA_IsTextEditPatternAvailablePropertyId);
+  const bool has_active_text_caret = HasActiveTextCaret(element);
+
+  if (!IsLikelyTextInput(control_type, supports_text_pattern,
+                         supports_value_pattern, supports_text_edit_pattern,
+                         has_active_text_caret, process_name)) {
+    return std::nullopt;
+  }
+  if (pointer_hit.has_value()) {
+    RECT bounding_rect = {};
+    if (FAILED(element->get_CurrentBoundingRectangle(&bounding_rect)) ||
+        !RectContainsPointWithTolerance(bounding_rect, pointer_hit.value())) {
+      return std::nullopt;
+    }
+  } else if (!WasFocusedByRecentPointerClick(element)) {
+    return std::nullopt;
+  }
+
+  TextFocusInfo info;
+  info.control_type_id = control_type;
+  info.process_id = process_id;
+  info.process_name = process_name;
+  info.supports_text_pattern = supports_text_pattern;
+  info.supports_value_pattern = supports_value_pattern;
+  info.supports_text_edit_pattern = supports_text_edit_pattern;
+  info.has_active_text_caret = has_active_text_caret;
+  info.is_password = GetBoolProperty(element, UIA_IsPasswordPropertyId);
+  info.is_read_only = GetBoolProperty(element, UIA_ValueIsReadOnlyPropertyId);
+  info.name = GetBstrProperty(element, &IUIAutomationElement::get_CurrentName);
+  info.localized_control_type =
+      GetBstrProperty(element,
+                      &IUIAutomationElement::get_CurrentLocalizedControlType);
+  info.class_name =
+      GetBstrProperty(element, &IUIAutomationElement::get_CurrentClassName);
+  info.automation_id =
+      GetBstrProperty(element, &IUIAutomationElement::get_CurrentAutomationId);
+  if (info.localized_control_type.empty()) {
+    info.localized_control_type = ControlTypeName(control_type);
+  }
+
+  UIA_HWND hwnd = nullptr;
+  if (SUCCEEDED(element->get_CurrentNativeWindowHandle(&hwnd))) {
+    info.native_window_handle = reinterpret_cast<int64_t>(hwnd);
+  }
+
+  info.timestamp_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  return info;
+}
+
+std::optional<TextFocusInfo> FindTextInputFromPoint(IUIAutomation* automation,
+                                                    POINT point) {
+  if (automation == nullptr) {
+    return std::nullopt;
+  }
+
+  IUIAutomationElement* element = nullptr;
+  if (FAILED(automation->ElementFromPoint(point, &element)) ||
+      element == nullptr) {
+    return std::nullopt;
+  }
+
+  IUIAutomationTreeWalker* walker = nullptr;
+  automation->get_ControlViewWalker(&walker);
+
+  IUIAutomationElement* current = element;
+  while (current != nullptr) {
+    auto info = BuildTextFocusInfo(current, point);
+    if (info.has_value()) {
+      current->Release();
+      if (walker != nullptr) {
+        walker->Release();
+      }
+      return info;
+    }
+
+    IUIAutomationElement* parent = nullptr;
+    if (walker == nullptr ||
+        FAILED(walker->GetParentElement(current, &parent)) ||
+        parent == nullptr) {
+      current->Release();
+      break;
+    }
+    current->Release();
+    current = parent;
+  }
+
+  if (walker != nullptr) {
+    walker->Release();
+  }
+  return std::nullopt;
+}
+
+void NotifyCallbacks(const TextFocusInfo& info) {
+  const std::string key =
+      std::to_string(info.process_id) + "|" +
+      std::to_string(info.native_window_handle) + "|" +
+      std::to_string(info.control_type_id) + "|" + info.class_name + "|" +
+      info.automation_id + "|" + info.name;
+  const ULONGLONG now = GetTickCount64();
+  {
+    std::lock_guard<std::mutex> lock(g_notify_mutex);
+    if (key == g_last_notify_key &&
+        now - g_last_notify_tick_ms < kDuplicateNotifyWindowMs) {
+      return;
+    }
+    g_last_notify_key = key;
+    g_last_notify_tick_ms = now;
+  }
+
+  std::vector<TextFocusMonitor::Callback> callbacks;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    callbacks.reserve(g_callbacks.size());
+    for (const auto& pair : g_callbacks) {
+      callbacks.push_back(pair.second);
+    }
+  }
+
+  for (const auto& callback : callbacks) {
+    callback(info);
+  }
+}
+
+class FocusChangedHandler final
+    : public IUIAutomationFocusChangedEventHandler {
+ public:
+  FocusChangedHandler() = default;
+
+  ULONG STDMETHODCALLTYPE AddRef() override {
+    return ++ref_count_;
+  }
+
+  ULONG STDMETHODCALLTYPE Release() override {
+    const auto count = --ref_count_;
+    if (count == 0) {
+      delete this;
+    }
+    return count;
+  }
+
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,
+                                           void** object) override {
+    if (object == nullptr) {
+      return E_POINTER;
+    }
+    if (riid == __uuidof(IUnknown) ||
+        riid == __uuidof(IUIAutomationFocusChangedEventHandler)) {
+      *object = static_cast<IUIAutomationFocusChangedEventHandler*>(this);
+      AddRef();
+      return S_OK;
+    }
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  HRESULT STDMETHODCALLTYPE HandleFocusChangedEvent(
+      IUIAutomationElement* sender) override {
+    auto info = BuildTextFocusInfo(sender);
+    if (info.has_value()) {
+      NotifyCallbacks(info.value());
+    }
+    return S_OK;
+  }
+
+ private:
+  std::atomic<ULONG> ref_count_{1};
+};
+
+LRESULT CALLBACK LowLevelMouseProc(int code, WPARAM wparam, LPARAM lparam) {
+  if (code >= 0 && (wparam == WM_LBUTTONDOWN || wparam == WM_LBUTTONUP)) {
+    auto* mouse = reinterpret_cast<MSLLHOOKSTRUCT*>(lparam);
+    if (mouse != nullptr) {
+      std::lock_guard<std::mutex> lock(g_pointer_mutex);
+      g_last_pointer_pos = mouse->pt;
+      g_last_pointer_tick_ms = GetTickCount64();
+    }
+    if (wparam == WM_LBUTTONUP && g_worker_thread_id != 0) {
+      PostThreadMessageW(g_worker_thread_id, kInspectPointerClickMessage, 0,
+                         0);
+    }
+  }
+  return CallNextHookEx(nullptr, code, wparam, lparam);
+}
+
+void PumpUntilStopped(HANDLE stop_event, IUIAutomation* automation = nullptr) {
+  while (true) {
+    const DWORD wait_result =
+        MsgWaitForMultipleObjects(1, &stop_event, FALSE, INFINITE,
+                                  QS_ALLINPUT);
+    if (wait_result == WAIT_OBJECT_0) {
+      return;
+    }
+    if (wait_result != WAIT_OBJECT_0 + 1) {
+      return;
+    }
+
+    MSG message;
+    while (PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+      if (message.message == kInspectPointerClickMessage) {
+        POINT pointer_pos = {};
+        bool has_pointer = false;
+        {
+          std::lock_guard<std::mutex> lock(g_pointer_mutex);
+          if (g_last_pointer_pos.has_value()) {
+            pointer_pos = g_last_pointer_pos.value();
+            has_pointer = true;
+          }
+        }
+        if (has_pointer) {
+          auto info = FindTextInputFromPoint(automation, pointer_pos);
+          if (info.has_value()) {
+            NotifyCallbacks(info.value());
+          }
+        }
+        continue;
+      }
+      TranslateMessage(&message);
+      DispatchMessage(&message);
+    }
+  }
+}
+
+void MonitorThread(HANDLE stop_event) {
+  const HRESULT coinit_hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  const bool com_initialized = SUCCEEDED(coinit_hr);
+  if (!com_initialized) {
+    PumpUntilStopped(stop_event);
+    return;
+  }
+
+  IUIAutomation* automation = nullptr;
+  HRESULT hr = CoCreateInstance(CLSID_CUIAutomation, nullptr,
+                                CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&automation));
+  if (FAILED(hr) || automation == nullptr) {
+    CoUninitialize();
+    PumpUntilStopped(stop_event);
+    return;
+  }
+
+  auto* handler = new FocusChangedHandler();
+  const bool handler_registered =
+      SUCCEEDED(automation->AddFocusChangedEventHandler(nullptr, handler));
+
+  MSG warmup_message;
+  PeekMessage(&warmup_message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+  g_worker_thread_id = GetCurrentThreadId();
+  HHOOK mouse_hook = SetWindowsHookExW(WH_MOUSE_LL, LowLevelMouseProc,
+                                       GetModuleHandleW(nullptr), 0);
+
+  PumpUntilStopped(stop_event, automation);
+
+  if (mouse_hook != nullptr) {
+    UnhookWindowsHookEx(mouse_hook);
+  }
+  g_worker_thread_id = 0;
+
+  if (handler_registered) {
+    automation->RemoveFocusChangedEventHandler(handler);
+  }
+  handler->Release();
+  automation->Release();
+  CoUninitialize();
+}
+
+void StopWorkerIfIdle() {
+  HANDLE stop_event = nullptr;
+  std::thread worker;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (!g_running || !g_callbacks.empty()) {
+      return;
+    }
+    stop_event = g_stop_event;
+    if (stop_event != nullptr) {
+      SetEvent(stop_event);
+    }
+    worker = std::move(g_worker);
+    g_stop_event = nullptr;
+    g_running = false;
+  }
+
+  if (worker.joinable()) {
+    worker.join();
+  }
+  if (stop_event != nullptr) {
+    CloseHandle(stop_event);
+  }
+}
+
+}  // namespace
+
+void TextFocusMonitor::Start(Callback callback, int callback_id) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  g_callbacks[callback_id] = std::move(callback);
+  if (g_running) {
+    return;
+  }
+
+  g_stop_event = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+  if (g_stop_event == nullptr) {
+    g_callbacks.erase(callback_id);
+    return;
+  }
+  g_running = true;
+  g_worker = std::thread(MonitorThread, g_stop_event);
+}
+
+void TextFocusMonitor::Stop(int callback_id) {
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_callbacks.erase(callback_id);
+  }
+  StopWorkerIfIdle();
+}
+
+void TextFocusMonitor::StopAll() {
+  HANDLE stop_event = nullptr;
+  std::thread worker;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_callbacks.clear();
+    if (!g_running) {
+      return;
+    }
+    stop_event = g_stop_event;
+    if (stop_event != nullptr) {
+      SetEvent(stop_event);
+    }
+    worker = std::move(g_worker);
+    g_stop_event = nullptr;
+    g_running = false;
+  }
+
+  if (worker.joinable()) {
+    worker.join();
+  }
+  if (stop_event != nullptr) {
+    CloseHandle(stop_event);
+  }
+}
+
+}  // namespace hardware_simulator

--- a/windows/text_focus_monitor.h
+++ b/windows/text_focus_monitor.h
@@ -1,0 +1,39 @@
+#ifndef FLUTTER_PLUGIN_HARDWARE_SIMULATOR_TEXT_FOCUS_MONITOR_H_
+#define FLUTTER_PLUGIN_HARDWARE_SIMULATOR_TEXT_FOCUS_MONITOR_H_
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace hardware_simulator {
+
+struct TextFocusInfo {
+  std::string name;
+  std::string localized_control_type;
+  std::string class_name;
+  std::string automation_id;
+  std::string process_name;
+  int control_type_id = 0;
+  int process_id = 0;
+  int64_t native_window_handle = 0;
+  bool is_password = false;
+  bool is_read_only = false;
+  bool supports_text_pattern = false;
+  bool supports_value_pattern = false;
+  bool supports_text_edit_pattern = false;
+  bool has_active_text_caret = false;
+  int64_t timestamp_ms = 0;
+};
+
+class TextFocusMonitor {
+ public:
+  using Callback = std::function<void(const TextFocusInfo&)>;
+
+  static void Start(Callback callback, int callback_id);
+  static void Stop(int callback_id);
+  static void StopAll();
+};
+
+}  // namespace hardware_simulator
+
+#endif  // FLUTTER_PLUGIN_HARDWARE_SIMULATOR_TEXT_FOCUS_MONITOR_H_


### PR DESCRIPTION
## Summary
- add Windows UI Automation text focus listener callbacks to hardware_simulator
- gate events to recent user pointer clicks and filter non-editable document surfaces without an active caret
- add an example app panel showing the latest 3 focused text targets
- refresh example generated plugin registrants after pointer_lock removal

## Verification
- dart format lib example\lib
- flutter test
- flutter analyze --no-fatal-infos --no-fatal-warnings
- flutter build windows --release

## Notes
- Strict `flutter analyze` still reports existing example lint/info/warning noise; no analyzer errors were introduced.
- Windows release preview: `D:\Dev\cloudplayplus2026\cloudplayplus\plugins\hardware_simulator\example\build\windows\x64\runner\Release\hardware_simulator_example.exe`