### PR TITLE
fix(input): align native scroll handling

### DIFF
--- a/ios/Classes/HardwareSimulatorPlugin.swift
+++ b/ios/Classes/HardwareSimulatorPlugin.swift
@@ -254,17 +254,18 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
             ])
         }
         
-        mouseInput.scroll.yAxis.valueChangedHandler = { [weak self] axis, value in
+        // Match the client-side PointerPanZoom/touch scroll convention.
+        mouseInput.scroll.xAxis.valueChangedHandler = { [weak self] axis, value in
             self?.channel?.invokeMethod("onCursorScroll", arguments: [
-                "dx": Double(value),
+                "dx": -Double(value),
                 "dy": 0
             ])
         }
         
-        mouseInput.scroll.xAxis.valueChangedHandler = { [weak self] axis, value in
+        mouseInput.scroll.yAxis.valueChangedHandler = { [weak self] axis, value in
             self?.channel?.invokeMethod("onCursorScroll", arguments: [
                 "dx": 0,
-                "dy": Double(value)
+                "dy": -Double(value)
             ])
         }
     }

--- a/ios/Classes/HardwareSimulatorPlugin.swift
+++ b/ios/Classes/HardwareSimulatorPlugin.swift
@@ -254,15 +254,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
             ])
         }
         
-        // Match the client-side PointerPanZoom/touch scroll convention.
-        mouseInput.scroll.xAxis.valueChangedHandler = { [weak self] axis, value in
+        mouseInput.scroll.yAxis.valueChangedHandler = { [weak self] axis, value in
             self?.channel?.invokeMethod("onCursorScroll", arguments: [
                 "dx": -Double(value),
                 "dy": 0
             ])
         }
         
-        mouseInput.scroll.yAxis.valueChangedHandler = { [weak self] axis, value in
+        mouseInput.scroll.xAxis.valueChangedHandler = { [weak self] axis, value in
             self?.channel?.invokeMethod("onCursorScroll", arguments: [
                 "dx": 0,
                 "dy": -Double(value)

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -839,13 +839,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   func performMouseScroll(dx: Double, dy: Double) {
       let eventSource = CGEventSource(stateID: .hidSystemState)
-      
-      if dy != 0, let scrollEventY = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: 1, wheel1: Int32(dy), wheel2: 0, wheel3: 0) {
-          scrollEventY.post(tap: .cghidEventTap)
-      }
 
-      if dx != 0, let scrollEventX = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: 1, wheel1: 0, wheel2: Int32(dx), wheel3: 0) {
-          scrollEventX.post(tap: .cghidEventTap)
+      if dx != 0 || dy != 0 {
+          let wheelCount: UInt32 = dx != 0 ? 2 : 1
+          if let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: wheelCount, wheel1: Int32(dy), wheel2: Int32(dx), wheel3: 0) {
+              scrollEvent.post(tap: .cghidEventTap)
+          }
       }
   }
 


### PR DESCRIPTION
## Summary
- align iOS native trackpad scroll callbacks with the app-side scroll convention
- keep both native iOS scroll axes inverted for the verified iPad trackpad behavior
- emit macOS horizontal scroll with wheelCount=2 so wheel2 is honored

## Validation
- flutter test
- verified via CloudPlayPlus iOS build/install during tuning