### PR TITLE
feat(macos): add virtual display primary-only mode

### DIFF
--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -385,6 +385,10 @@ class HardwareSimulator {
     return HardwareSimulatorPlatform.instance.hasPendingConfiguration();
   }
 
+  static Future<String?> getLastDisplayError() {
+    return HardwareSimulatorPlatform.instance.getLastDisplayError();
+  }
+
   static Future<void> setDragWindowContents(bool enabled) {
     return HardwareSimulatorPlatform.instance.setDragWindowContents(enabled);
   }

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -573,6 +573,11 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   }
 
   @override
+  Future<String?> getLastDisplayError() async {
+    return await methodChannel.invokeMethod<String>('getLastDisplayError');
+  }
+
+  @override
   Future<bool> putImmersiveModeEnabled(bool enabled) async {
     return await methodChannel.invokeMethod('putImmersiveModeEnabled', {
       'enabled': enabled,

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -330,6 +330,10 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
         'hasPendingConfiguration() has not been implemented.');
   }
 
+  Future<String?> getLastDisplayError() async {
+    return null;
+  }
+
   Future<void> setDragWindowContents(bool enabled) async {
     throw UnimplementedError(
         'setDragWindowContents() has not been implemented.');

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -637,6 +637,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return waitForMacMainDisplay(targetDisplayId)
   }
 
+  private func setMacPrimaryDisplay(_ displayId: Int) -> Bool {
+    let targetDisplayId = CGDirectDisplayID(displayId)
+    guard CGDisplayIsActive(targetDisplayId) != 0 else {
+      return false
+    }
+    return setMacMainDisplay(targetDisplayId, displayIds: activeMacDisplayIds())
+  }
+
   private func setMacPrimaryDisplayOnly(_ displayId: Int) -> Bool {
     func rollbackMacDisplayConfiguration() {
       let backup = macDisplayConfigurationBackup
@@ -1858,6 +1866,13 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       result(false)
     case "getDisplayOrientation":
       result(0)
+    case "setPrimaryDisplay":
+      let args = call.arguments as? [String: Any]
+      let displayUid = args?["displayIndex"] as? Int ?? -1
+      macVirtualDisplayQueue.async {
+        let ok = self.setMacPrimaryDisplay(displayUid)
+        DispatchQueue.main.async { result(ok) }
+      }
     case "setMultiDisplayMode":
       let args = call.arguments as? [String: Any]
       let mode = args?["mode"] as? Int ?? 4
@@ -1922,6 +1937,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       result(false)
     case "getDisplayOrientation":
       result(0)
+    case "setPrimaryDisplay":
+      result(false)
     case "setMultiDisplayMode":
       result(false)
     case "getCurrentMultiDisplayMode":

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -38,6 +38,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     label: "com.cloudplayplus.hardware-simulator.virtual-display"
   )
   private var macVirtualDisplayProcesses: [Int: Process] = [:]
+  private var macVirtualDisplaySerials: [Int: Int] = [:]
   private var macDisplayConfigurationBackup: [MacDisplayBackupItem]? = nil
   private var macSkyLightHandle: UnsafeMutableRawPointer?
   private lazy var macSLSDisplayConfig = MacSLSDisplayConfig.load(
@@ -283,6 +284,18 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return macVirtualDisplayQueue.sync(execute: body)
   }
 
+  private func nextMacVirtualDisplaySerial() -> Int {
+    let usedSerials = Set(macVirtualDisplaySerials.values)
+    let serialBase = 0x4350_5600
+    for slot in 1...255 {
+      let serial = serialBase + slot
+      if !usedSerials.contains(serial) {
+        return serial
+      }
+    }
+    return serialBase + macVirtualDisplaySerials.count + 1
+  }
+
   private func spawnMacVirtualDisplay(
     width: Int,
     height: Int,
@@ -294,12 +307,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
     let process = Process()
     let output = Pipe()
+    let serial = nextMacVirtualDisplaySerial()
     process.executableURL = helper
     process.arguments = [
       "\(width)",
       "\(height)",
       "\(refreshRate)",
       "\(ProcessInfo.processInfo.processIdentifier)",
+      "\(serial)",
     ]
     process.standardOutput = output
     process.standardError = FileHandle.standardError
@@ -327,10 +342,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     process.terminationHandler = { [weak self] _ in
       self?.macVirtualDisplayQueue.async {
         self?.macVirtualDisplayProcesses.removeValue(forKey: displayId)
+        self?.macVirtualDisplaySerials.removeValue(forKey: displayId)
       }
     }
     withMacVirtualDisplayProcesses {
       macVirtualDisplayProcesses[displayId] = process
+      macVirtualDisplaySerials[displayId] = serial
     }
     Thread.sleep(forTimeInterval: 1.0)
     return displayId
@@ -343,7 +360,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       _ = restoreMacDisplayConfiguration()
     }
     let process: Process? = withMacVirtualDisplayProcesses {
-      macVirtualDisplayProcesses.removeValue(forKey: displayId)
+      macVirtualDisplaySerials.removeValue(forKey: displayId)
+      return macVirtualDisplayProcesses.removeValue(forKey: displayId)
     }
     guard let process else {
       return false
@@ -360,6 +378,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         process.terminate()
       }
       macVirtualDisplayProcesses.removeAll()
+      macVirtualDisplaySerials.removeAll()
     }
   }
 

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -3,6 +3,7 @@ import FlutterMacOS
 import CommonCrypto
 import CoreGraphics
 import ApplicationServices
+import Darwin
 
 class CursorConstants {    
   static let cursorVisible = 2
@@ -37,6 +38,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     label: "com.cloudplayplus.hardware-simulator.virtual-display"
   )
   private var macVirtualDisplayProcesses: [Int: Process] = [:]
+  private var macDisplayConfigurationBackup: [MacDisplayBackupItem]? = nil
+  private var macSkyLightHandle: UnsafeMutableRawPointer?
+  private lazy var macSLSDisplayConfig = MacSLSDisplayConfig.load(
+    using: { [weak self] in self?.loadMacSkyLight() }
+  )
   private let macCustomDisplayConfigsKey =
     "com.cloudplayplus.hardware_simulator.macos.custom_display_configs"
   private let macHelperName = "cloudplayplus_vd_helper"
@@ -52,6 +58,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   deinit {
+    _ = restoreMacDisplayConfiguration()
     terminateAllMacVirtualDisplays()
   }
 
@@ -66,6 +73,92 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let refreshRate: Int
   }
 
+  private struct MacDisplayBackupItem {
+    let displayId: CGDirectDisplayID
+    let mode: CGDisplayMode?
+    let origin: CGPoint
+    let mirrorTarget: CGDirectDisplayID
+  }
+
+  private struct MacSLSDisplayConfig {
+    typealias BeginFn = @convention(c) (
+      UnsafeMutablePointer<CGDisplayConfigRef?>
+    ) -> CGError
+    typealias ConfigureEnabledFn = @convention(c) (
+      CGDisplayConfigRef?,
+      CGDirectDisplayID,
+      Bool
+    ) -> CGError
+    typealias ConfigureOriginFn = @convention(c) (
+      CGDisplayConfigRef?,
+      CGDirectDisplayID,
+      Int32,
+      Int32
+    ) -> CGError
+    typealias CompleteFn = @convention(c) (
+      CGDisplayConfigRef?,
+      CGConfigureOption,
+      UInt32
+    ) -> CGError
+
+    let begin: BeginFn
+    let configureEnabled: ConfigureEnabledFn
+    let configureOrigin: ConfigureOriginFn
+    let complete: CompleteFn
+
+    static func load(
+      using loadSkyLight: () -> UnsafeMutableRawPointer?
+    ) -> MacSLSDisplayConfig? {
+      guard let handle = loadSkyLight() else {
+        return nil
+      }
+
+      func symbol<T>(_ name: String, as type: T.Type) -> T? {
+        guard let pointer = dlsym(handle, name) else {
+          return nil
+        }
+        return unsafeBitCast(pointer, to: type)
+      }
+
+      guard
+        let begin = symbol("SLSBeginDisplayConfiguration", as: BeginFn.self),
+        let configureEnabled = symbol(
+          "SLSConfigureDisplayEnabled",
+          as: ConfigureEnabledFn.self
+        ),
+        let configureOrigin = symbol(
+          "SLSConfigureDisplayOrigin",
+          as: ConfigureOriginFn.self
+        ),
+        let complete = symbol(
+          "SLSCompleteDisplayConfiguration",
+          as: CompleteFn.self
+        )
+      else {
+        return nil
+      }
+
+      return MacSLSDisplayConfig(
+        begin: begin,
+        configureEnabled: configureEnabled,
+        configureOrigin: configureOrigin,
+        complete: complete
+      )
+    }
+  }
+
+  private func loadMacSkyLight() -> UnsafeMutableRawPointer? {
+    if let macSkyLightHandle {
+      return macSkyLightHandle
+    }
+    let path = "/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight"
+    guard let handle = dlopen(path, RTLD_NOW) else {
+      return nil
+    }
+    macSkyLightHandle = handle
+    return handle
+  }
+
   private func macHelperURL() -> URL? {
     return Bundle.main.bundleURL
       .appendingPathComponent("Contents")
@@ -75,6 +168,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func macVirtualDisplayAvailable() -> Bool {
     guard #available(macOS 14.0, *) else {
+      return false
+    }
+    guard loadMacSkyLight() != nil else {
       return false
     }
     guard NSClassFromString("CGVirtualDisplay") != nil else {
@@ -241,6 +337,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func terminateMacVirtualDisplay(_ displayId: Int) -> Bool {
+    if macDisplayConfigurationBackup?.contains(
+      where: { Int($0.displayId) == displayId }
+    ) == true {
+      _ = restoreMacDisplayConfiguration()
+    }
     let process: Process? = withMacVirtualDisplayProcesses {
       macVirtualDisplayProcesses.removeValue(forKey: displayId)
     }
@@ -437,6 +538,152 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       )
     }
     return CGCompleteDisplayConfiguration(config, .forAppOnly) == .success
+  }
+
+  private func activeMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
+    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: limit)
+    var displayCount: UInt32 = 0
+    guard
+      CGGetActiveDisplayList(UInt32(displayIds.count), &displayIds, &displayCount)
+        == .success
+    else {
+      return []
+    }
+    return Array(displayIds.prefix(Int(displayCount)))
+  }
+
+  private func saveMacDisplayConfiguration() -> Bool {
+    let displayIds = activeMacDisplayIds()
+    guard !displayIds.isEmpty else {
+      return false
+    }
+
+    macDisplayConfigurationBackup = displayIds.map { displayId in
+      let bounds = CGDisplayBounds(displayId)
+      return MacDisplayBackupItem(
+        displayId: displayId,
+        mode: CGDisplayCopyDisplayMode(displayId),
+        origin: bounds.origin,
+        mirrorTarget: CGDisplayMirrorsDisplay(displayId)
+      )
+    }
+    return true
+  }
+
+  private func setMacPrimaryDisplayOnly(_ displayId: Int) -> Bool {
+    guard macDisplayConfigurationBackup == nil else {
+      return false
+    }
+    guard macVirtualDisplayIdsSnapshot().contains(displayId) else {
+      return false
+    }
+    let targetDisplayId = CGDirectDisplayID(displayId)
+    guard CGDisplayIsActive(targetDisplayId) != 0 else {
+      return false
+    }
+    guard saveMacDisplayConfiguration(), let sls = macSLSDisplayConfig else {
+      macDisplayConfigurationBackup = nil
+      return false
+    }
+
+    var config: CGDisplayConfigRef?
+    guard sls.begin(&config) == .success, let config else {
+      macDisplayConfigurationBackup = nil
+      return false
+    }
+
+    let displayIds = activeMacDisplayIds()
+    for id in displayIds {
+      let enable = id == targetDisplayId
+      if sls.configureEnabled(config, id, enable) != .success {
+        macDisplayConfigurationBackup = nil
+        return false
+      }
+      if enable &&
+        sls.configureOrigin(config, id, 0, 0) != .success {
+        macDisplayConfigurationBackup = nil
+        return false
+      }
+    }
+
+    if sls.complete(config, .forSession, 0) != .success {
+      let backup = macDisplayConfigurationBackup
+      macDisplayConfigurationBackup = nil
+      if backup != nil {
+        _ = restoreMacDisplayConfiguration(from: backup)
+      }
+      return false
+    }
+
+    Thread.sleep(forTimeInterval: 0.5)
+    return true
+  }
+
+  private func restoreMacDisplayConfiguration(
+    from backupOverride: [MacDisplayBackupItem]? = nil
+  ) -> Bool {
+    guard let backup = backupOverride ?? macDisplayConfigurationBackup else {
+      return true
+    }
+    guard let sls = macSLSDisplayConfig else {
+      return false
+    }
+
+    var config: CGDisplayConfigRef?
+    guard sls.begin(&config) == .success, let config else {
+      return false
+    }
+
+    for item in backup {
+      guard sls.configureEnabled(config, item.displayId, true) == .success else {
+        return false
+      }
+      guard
+        sls.configureOrigin(
+          config,
+          item.displayId,
+          Int32(item.origin.x.rounded()),
+          Int32(item.origin.y.rounded())
+        ) == .success
+      else {
+        return false
+      }
+    }
+
+    guard sls.complete(config, .forSession, 0) == .success else {
+      return false
+    }
+
+    for item in backup {
+      if let mode = item.mode {
+        _ = CGDisplaySetDisplayMode(item.displayId, mode, nil)
+      }
+    }
+
+    var mirrorConfig: CGDisplayConfigRef?
+    if CGBeginDisplayConfiguration(&mirrorConfig) == .success,
+      let mirrorConfig {
+      for item in backup {
+        CGConfigureDisplayMirrorOfDisplay(
+          mirrorConfig,
+          item.displayId,
+          item.mirrorTarget == 0 ? kCGNullDirectDisplay : item.mirrorTarget
+        )
+        CGConfigureDisplayOrigin(
+          mirrorConfig,
+          item.displayId,
+          Int32(item.origin.x.rounded()),
+          Int32(item.origin.y.rounded())
+        )
+      }
+      _ = CGCompleteDisplayConfiguration(mirrorConfig, .forSession)
+    }
+
+    if backupOverride == nil {
+      macDisplayConfigurationBackup = nil
+    }
+    Thread.sleep(forTimeInterval: 0.5)
+    return true
   }
 #endif
 
@@ -1553,11 +1800,22 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         result(anyMirrored ? 3 : 0)
       }
     case "setPrimaryDisplayOnly":
-      result(false)
+      let args = call.arguments as? [String: Any]
+      let displayUid = args?["displayUid"] as? Int ?? -1
+      macVirtualDisplayQueue.async {
+        let ok = self.setMacPrimaryDisplayOnly(displayUid)
+        DispatchQueue.main.async { result(ok) }
+      }
     case "restoreDisplayConfiguration":
-      result(false)
+      macVirtualDisplayQueue.async {
+        let ok = self.restoreMacDisplayConfiguration()
+        DispatchQueue.main.async { result(ok) }
+      }
     case "hasPendingConfiguration":
-      result(false)
+      macVirtualDisplayQueue.async {
+        let hasPending = self.macDisplayConfigurationBackup != nil
+        DispatchQueue.main.async { result(hasPending) }
+      }
     case "updateStaticMonitors":
       result(nil)
 #else

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -616,27 +616,15 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
     for id in displayIds {
       let shouldEnable = enabled(id)
+      if isMacDisplayEnabled(id) == shouldEnable {
+        continue
+      }
       let enabledError = sls.configureEnabled(config, id, shouldEnable)
       guard enabledError == .success else {
         CGCancelDisplayConfiguration(config)
         return setMacDisplayError(
           "SLSConfigureDisplayEnabled(\(id), \(shouldEnable)) failed: \(macCGErrorDescription(enabledError))"
         )
-      }
-      if shouldEnable {
-        let bounds = CGDisplayBounds(id)
-        let originError = CGConfigureDisplayOrigin(
-          config,
-          id,
-          Int32(bounds.origin.x.rounded()),
-          Int32(bounds.origin.y.rounded())
-        )
-        guard originError == .success else {
-          CGCancelDisplayConfiguration(config)
-          return setMacDisplayError(
-            "CGConfigureDisplayOrigin(enable \(id)) failed: \(macCGErrorDescription(originError))"
-          )
-        }
       }
     }
 
@@ -965,13 +953,6 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       rollbackMacDisplayConfiguration()
       return false
     }
-    guard let sls = macSLSDisplayConfig else {
-      rollbackMacDisplayConfiguration()
-      return setMacDisplayError(
-        "SkyLight display configuration symbols are unavailable"
-      )
-    }
-
     guard configureMacDisplayEnabled(displayIds, enabled: { id in
       id == targetDisplayId || CGDisplayIsActive(id) != 0
     }) else {
@@ -996,43 +977,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       return false
     }
 
-    var config: CGDisplayConfigRef?
-    let beginError = CGBeginDisplayConfiguration(&config)
-    guard beginError == .success, let config else {
+    guard configureMacDisplayEnabled(allMacDisplayIds(), enabled: { id in
+      id == targetDisplayId
+    }) else {
       rollbackMacDisplayConfiguration()
-      return setMacDisplayError(
-        "CGBeginDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(beginError))"
-      )
-    }
-
-    for id in allMacDisplayIds() {
-      let enable = id == targetDisplayId
-      let enabledError = sls.configureEnabled(config, id, enable)
-      if enabledError != .success {
-        CGCancelDisplayConfiguration(config)
-        rollbackMacDisplayConfiguration()
-        return setMacDisplayError(
-          "SLSConfigureDisplayEnabled(primary-only \(id), \(enable)) failed: \(macCGErrorDescription(enabledError))"
-        )
-      }
-      if enable {
-        let originError = CGConfigureDisplayOrigin(config, id, 0, 0)
-        if originError != .success {
-          CGCancelDisplayConfiguration(config)
-          rollbackMacDisplayConfiguration()
-          return setMacDisplayError(
-            "CGConfigureDisplayOrigin(primary-only \(id)) failed: \(macCGErrorDescription(originError))"
-          )
-        }
-      }
-    }
-
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    if completeError != .success {
-      rollbackMacDisplayConfiguration()
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(completeError))"
-      )
+      return false
     }
 
     Thread.sleep(forTimeInterval: 0.5)
@@ -1061,48 +1010,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     guard let backup = backupOverride ?? macDisplayConfigurationBackup else {
       return true
     }
-    guard let sls = macSLSDisplayConfig else {
-      return setMacDisplayError(
-        "SkyLight display configuration symbols are unavailable"
-      )
-    }
+    let displayIds = backup.map { $0.displayId }
 
-    var config: CGDisplayConfigRef?
-    let beginError = CGBeginDisplayConfiguration(&config)
-    guard beginError == .success, let config else {
-      return setMacDisplayError(
-        "CGBeginDisplayConfiguration(restore) failed: \(macCGErrorDescription(beginError))"
-      )
+    guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
+      return false
     }
-
-    for item in backup {
-      let enabledError = sls.configureEnabled(config, item.displayId, true)
-      guard enabledError == .success else {
-        CGCancelDisplayConfiguration(config)
-        return setMacDisplayError(
-          "SLSConfigureDisplayEnabled(restore \(item.displayId)) failed: \(macCGErrorDescription(enabledError))"
-        )
-      }
-      let originError = CGConfigureDisplayOrigin(
-        config,
-        item.displayId,
-        Int32(item.origin.x.rounded()),
-        Int32(item.origin.y.rounded())
-      )
-      guard originError == .success else {
-        CGCancelDisplayConfiguration(config)
-        return setMacDisplayError(
-          "CGConfigureDisplayOrigin(restore \(item.displayId)) failed: \(macCGErrorDescription(originError))"
-        )
-      }
-    }
-
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    guard completeError == .success else {
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(restore) failed: \(macCGErrorDescription(completeError))"
-      )
-    }
+    Thread.sleep(forTimeInterval: 0.3)
 
     for item in backup {
       if let mode = item.mode {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -790,11 +790,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func getCurrentMacMultiDisplayMode() -> Int {
     let activeIds = activeMacDisplayIds()
-    let displayIds = allMacDisplayIds()
     guard !activeIds.isEmpty else {
       return 4
     }
     if activeIds.count <= 1 {
+      let displayIds = macDisplayConfigurationBackup?.map { $0.displayId }
+        ?? allMacDisplayIds()
       guard let activeId = activeIds.first,
         let index = displayIds.firstIndex(of: activeId)
       else {
@@ -809,10 +810,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     if mirroredCount > 0 {
       return 3
     }
-    if activeIds.count == displayIds.count {
-      return 0
-    }
-    return 4
+    return 0
   }
 
   private func activeMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
@@ -859,6 +857,21 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let deadline = Date().addingTimeInterval(timeout)
     repeat {
       if CGMainDisplayID() == displayId || CGDisplayIsMain(displayId) != 0 {
+        return true
+      }
+      Thread.sleep(forTimeInterval: 0.1)
+    } while Date() < deadline
+    return false
+  }
+
+  private func waitForMacPrimaryOnlyTopology(
+    _ displayId: CGDirectDisplayID,
+    timeout: TimeInterval = 1.5
+  ) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      let activeIds = activeMacDisplayIds()
+      if activeIds.count == 1 && activeIds.first == displayId {
         return true
       }
       Thread.sleep(forTimeInterval: 0.1)
@@ -1016,6 +1029,13 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       rollbackMacDisplayConfiguration()
       return setMacDisplayError(
         "Timed out waiting for display \(targetDisplayId) to remain main"
+      )
+    }
+    guard waitForMacPrimaryOnlyTopology(targetDisplayId) else {
+      let activeIds = activeMacDisplayIds().map(String.init).joined(separator: ",")
+      rollbackMacDisplayConfiguration()
+      return setMacDisplayError(
+        "Timed out waiting for primary-only topology; active displays: [\(activeIds)]"
       )
     }
     return true
@@ -2206,15 +2226,20 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     case "setMultiDisplayMode":
       let args = call.arguments as? [String: Any]
       let mode = args?["mode"] as? Int ?? 4
+      let primaryDisplayId = args?["primaryDisplayId"] as? Int ?? 0
       macVirtualDisplayQueue.async {
         let ok: Bool
         switch mode {
         case 0:
           ok = self.setMacExtendMode()
         case 1:
-          ok = self.setMacSingleDisplayMode(at: 0)
+          ok = primaryDisplayId > 0
+            ? self.setMacPrimaryDisplayOnly(primaryDisplayId)
+            : self.setMacSingleDisplayMode(at: 0)
         case 2:
-          ok = self.setMacSingleDisplayMode(at: 1)
+          ok = primaryDisplayId > 0
+            ? self.setMacPrimaryDisplayOnly(primaryDisplayId)
+            : self.setMacSingleDisplayMode(at: 1)
         case 3:
           ok = self.setMacDuplicateMode()
         default:

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -40,6 +40,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var macVirtualDisplayProcesses: [Int: Process] = [:]
   private var macVirtualDisplaySerials: [Int: Int] = [:]
   private var macDisplayConfigurationBackup: [MacDisplayBackupItem]? = nil
+  private var macLastVirtualDisplayError: String? = nil
   private var macSkyLightHandle: UnsafeMutableRawPointer?
   private lazy var macSLSDisplayConfig = MacSLSDisplayConfig.load(
     using: { [weak self] in self?.loadMacSkyLight() }
@@ -96,6 +97,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       Int32,
       Int32
     ) -> CGError
+    typealias GetDisplayListFn = @convention(c) (
+      UInt32,
+      UnsafeMutablePointer<CGDirectDisplayID>?,
+      UnsafeMutablePointer<UInt32>?
+    ) -> CGError
     typealias CompleteFn = @convention(c) (
       CGDisplayConfigRef?,
       CGConfigureOption,
@@ -105,6 +111,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let begin: BeginFn
     let configureEnabled: ConfigureEnabledFn
     let configureOrigin: ConfigureOriginFn
+    let getDisplayList: GetDisplayListFn
     let complete: CompleteFn
 
     static func load(
@@ -131,6 +138,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           "SLSConfigureDisplayOrigin",
           as: ConfigureOriginFn.self
         ),
+        let getDisplayList =
+          symbol("SLSGetDisplayList", as: GetDisplayListFn.self)
+          ?? symbol("CGSGetDisplayList", as: GetDisplayListFn.self),
         let complete = symbol(
           "SLSCompleteDisplayConfiguration",
           as: CompleteFn.self
@@ -143,6 +153,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         begin: begin,
         configureEnabled: configureEnabled,
         configureOrigin: configureOrigin,
+        getDisplayList: getDisplayList,
         complete: complete
       )
     }
@@ -158,6 +169,21 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
     macSkyLightHandle = handle
     return handle
+  }
+
+  private func clearMacDisplayError() {
+    macLastVirtualDisplayError = nil
+  }
+
+  private func macCGErrorDescription(_ error: CGError) -> String {
+    return "CGError(\(error.rawValue))"
+  }
+
+  @discardableResult
+  private func setMacDisplayError(_ message: String) -> Bool {
+    macLastVirtualDisplayError = message
+    NSLog("CloudPlayPlus macOS display: %@", message)
+    return false
   }
 
   private func macHelperURL() -> URL? {
@@ -532,34 +558,68 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     ) > 0
   }
 
-  private func onlineMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
-    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: limit)
-    var displayCount: UInt32 = 0
-    guard
-      CGGetOnlineDisplayList(UInt32(displayIds.count), &displayIds, &displayCount)
-        == .success
-    else {
+  private func allMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
+    guard let sls = macSLSDisplayConfig else {
+      setMacDisplayError("SkyLight display configuration symbols are unavailable")
       return []
     }
-    return Array(displayIds.prefix(Int(displayCount)))
+
+    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: limit)
+    var displayCount: UInt32 = 0
+    let error = displayIds.withUnsafeMutableBufferPointer { buffer in
+      sls.getDisplayList(UInt32(buffer.count), buffer.baseAddress, &displayCount)
+    }
+    guard error == .success else {
+      setMacDisplayError(
+        "SLSGetDisplayList failed: \(macCGErrorDescription(error))"
+      )
+      return []
+    }
+    return Array(displayIds.prefix(min(Int(displayCount), displayIds.count)))
   }
 
   private func unmirrorMacDisplays(_ displayIds: [CGDirectDisplayID]) -> Bool {
     var config: CGDisplayConfigRef?
-    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
-      return false
+    let beginError = CGBeginDisplayConfiguration(&config)
+    guard beginError == .success, let config else {
+      return setMacDisplayError(
+        "CGBeginDisplayConfiguration(unmirror) failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
+    var changed = false
     for id in displayIds {
-      guard
-        CGConfigureDisplayMirrorOfDisplay(config, id, kCGNullDirectDisplay)
-          == .success
+      guard CGDisplayIsInMirrorSet(id) != 0,
+        CGDisplayMirrorsDisplay(id) != 0
       else {
-        CGCancelDisplayConfiguration(config)
-        return false
+        continue
       }
+      let error = CGConfigureDisplayMirrorOfDisplay(
+        config,
+        id,
+        kCGNullDirectDisplay
+      )
+      guard error == .success else {
+        CGCancelDisplayConfiguration(config)
+        return setMacDisplayError(
+          "CGConfigureDisplayMirrorOfDisplay(unmirror \(id)) failed: \(macCGErrorDescription(error))"
+        )
+      }
+      changed = true
     }
-    return CGCompleteDisplayConfiguration(config, .forSession) == .success
+
+    guard changed else {
+      CGCancelDisplayConfiguration(config)
+      return true
+    }
+
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "CGCompleteDisplayConfiguration(unmirror) failed: \(macCGErrorDescription(completeError))"
+      )
+    }
+    return true
   }
 
   private func configureMacDisplayEnabled(
@@ -567,43 +627,59 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     enabled: (CGDirectDisplayID) -> Bool
   ) -> Bool {
     guard let sls = macSLSDisplayConfig else {
-      return false
+      return setMacDisplayError(
+        "SkyLight display configuration symbols are unavailable"
+      )
     }
 
     var config: CGDisplayConfigRef?
-    guard sls.begin(&config) == .success, let config else {
-      return false
+    let beginError = sls.begin(&config)
+    guard beginError == .success, let config else {
+      return setMacDisplayError(
+        "SLSBeginDisplayConfiguration failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
     for id in displayIds {
       let shouldEnable = enabled(id)
-      guard sls.configureEnabled(config, id, shouldEnable) == .success else {
+      let enabledError = sls.configureEnabled(config, id, shouldEnable)
+      guard enabledError == .success else {
         CGCancelDisplayConfiguration(config)
-        return false
+        return setMacDisplayError(
+          "SLSConfigureDisplayEnabled(\(id), \(shouldEnable)) failed: \(macCGErrorDescription(enabledError))"
+        )
       }
       if shouldEnable {
         let bounds = CGDisplayBounds(id)
-        guard
-          sls.configureOrigin(
-            config,
-            id,
-            Int32(bounds.origin.x.rounded()),
-            Int32(bounds.origin.y.rounded())
-          ) == .success
-        else {
+        let originError = sls.configureOrigin(
+          config,
+          id,
+          Int32(bounds.origin.x.rounded()),
+          Int32(bounds.origin.y.rounded())
+        )
+        guard originError == .success else {
           CGCancelDisplayConfiguration(config)
-          return false
+          return setMacDisplayError(
+            "SLSConfigureDisplayOrigin(\(id)) failed: \(macCGErrorDescription(originError))"
+          )
         }
       }
     }
 
-    return sls.complete(config, .forSession, 0) == .success
+    let completeError = sls.complete(config, .permanently, 0)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "SLSCompleteDisplayConfiguration(enable) failed: \(macCGErrorDescription(completeError))"
+      )
+    }
+    return true
   }
 
   private func setMacExtendMode() -> Bool {
-    let displayIds = onlineMacDisplayIds()
+    clearMacDisplayError()
+    let displayIds = allMacDisplayIds()
     guard !displayIds.isEmpty else {
-      return false
+      return setMacDisplayError("No displays found for extend mode")
     }
     guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
       return false
@@ -612,15 +688,18 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
     let activeIds = activeMacDisplayIds()
     guard !activeIds.isEmpty else {
-      return false
+      return setMacDisplayError("No active displays after enabling extend mode")
     }
     guard unmirrorMacDisplays(activeIds) else {
       return false
     }
 
     var config: CGDisplayConfigRef?
-    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
-      return false
+    let beginError = CGBeginDisplayConfiguration(&config)
+    guard beginError == .success, let config else {
+      return setMacDisplayError(
+        "CGBeginDisplayConfiguration(extend) failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
     let primary = activeIds.contains(CGMainDisplayID())
@@ -631,24 +710,31 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     var nextX: Int32 = 0
     for id in orderedIds {
       let bounds = CGDisplayBounds(id)
-      guard CGConfigureDisplayOrigin(config, id, nextX, 0) == .success else {
+      let originError = CGConfigureDisplayOrigin(config, id, nextX, 0)
+      guard originError == .success else {
         CGCancelDisplayConfiguration(config)
-        return false
+        return setMacDisplayError(
+          "CGConfigureDisplayOrigin(extend \(id)) failed: \(macCGErrorDescription(originError))"
+        )
       }
       nextX += Int32(bounds.width.rounded())
     }
 
-    guard CGCompleteDisplayConfiguration(config, .forSession) == .success else {
-      return false
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "CGCompleteDisplayConfiguration(extend) failed: \(macCGErrorDescription(completeError))"
+      )
     }
     macDisplayConfigurationBackup = nil
     return true
   }
 
   private func setMacDuplicateMode() -> Bool {
-    let displayIds = onlineMacDisplayIds()
+    clearMacDisplayError()
+    let displayIds = allMacDisplayIds()
     guard displayIds.count >= 2 else {
-      return false
+      return setMacDisplayError("Duplicate mode needs at least two displays")
     }
     guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
       return false
@@ -657,49 +743,60 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
     let activeIds = activeMacDisplayIds()
     guard activeIds.count >= 2 else {
-      return false
+      return setMacDisplayError(
+        "Duplicate mode has fewer than two active displays after enabling"
+      )
     }
     let primary = activeIds.contains(CGMainDisplayID())
       ? CGMainDisplayID()
       : activeIds[0]
 
     var config: CGDisplayConfigRef?
-    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
-      return false
+    let beginError = CGBeginDisplayConfiguration(&config)
+    guard beginError == .success, let config else {
+      return setMacDisplayError(
+        "CGBeginDisplayConfiguration(duplicate) failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
     for id in activeIds where id != primary {
-      guard CGConfigureDisplayMirrorOfDisplay(config, id, primary) == .success
-      else {
+      let mirrorError = CGConfigureDisplayMirrorOfDisplay(config, id, primary)
+      guard mirrorError == .success else {
         CGCancelDisplayConfiguration(config)
-        return false
+        return setMacDisplayError(
+          "CGConfigureDisplayMirrorOfDisplay(\(id) -> \(primary)) failed: \(macCGErrorDescription(mirrorError))"
+        )
       }
     }
 
-    guard CGCompleteDisplayConfiguration(config, .forSession) == .success else {
-      return false
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "CGCompleteDisplayConfiguration(duplicate) failed: \(macCGErrorDescription(completeError))"
+      )
     }
     macDisplayConfigurationBackup = nil
     return true
   }
 
   private func setMacSingleDisplayMode(at index: Int) -> Bool {
-    let displayIds = onlineMacDisplayIds()
+    clearMacDisplayError()
+    let displayIds = allMacDisplayIds()
     guard displayIds.indices.contains(index) else {
-      return false
+      return setMacDisplayError("Display index \(index) is unavailable")
     }
     return setMacPrimaryDisplayOnly(Int(displayIds[index]))
   }
 
   private func getCurrentMacMultiDisplayMode() -> Int {
     let activeIds = activeMacDisplayIds()
-    let onlineIds = onlineMacDisplayIds()
+    let displayIds = allMacDisplayIds()
     guard !activeIds.isEmpty else {
       return 4
     }
     if activeIds.count <= 1 {
       guard let activeId = activeIds.first,
-        let index = onlineIds.firstIndex(of: activeId)
+        let index = displayIds.firstIndex(of: activeId)
       else {
         return 1
       }
@@ -712,7 +809,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     if mirroredCount > 0 {
       return 3
     }
-    if activeIds.count == onlineIds.count {
+    if activeIds.count == displayIds.count {
       return 0
     }
     return 4
@@ -721,10 +818,15 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private func activeMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
     var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: limit)
     var displayCount: UInt32 = 0
-    guard
-      CGGetActiveDisplayList(UInt32(displayIds.count), &displayIds, &displayCount)
-        == .success
-    else {
+    let error = CGGetActiveDisplayList(
+      UInt32(displayIds.count),
+      &displayIds,
+      &displayCount
+    )
+    guard error == .success else {
+      setMacDisplayError(
+        "CGGetActiveDisplayList failed: \(macCGErrorDescription(error))"
+      )
       return []
     }
     return Array(displayIds.prefix(Int(displayCount)))
@@ -735,7 +837,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   ) -> Bool {
     let displayIds = inputDisplayIds ?? activeMacDisplayIds()
     guard !displayIds.isEmpty else {
-      return false
+      return setMacDisplayError("No displays available to save configuration")
     }
 
     macDisplayConfigurationBackup = displayIds.map { displayId in
@@ -769,7 +871,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     displayIds: [CGDirectDisplayID]
   ) -> Bool {
     guard displayIds.contains(targetDisplayId) else {
-      return false
+      return setMacDisplayError("Target display \(targetDisplayId) is not configurable")
     }
 
     let targetBounds = CGDisplayBounds(targetDisplayId)
@@ -777,36 +879,51 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let deltaY = -targetBounds.origin.y
 
     var config: CGDisplayConfigRef?
-    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
-      return false
+    let beginError = CGBeginDisplayConfiguration(&config)
+    guard beginError == .success, let config else {
+      return setMacDisplayError(
+        "CGBeginDisplayConfiguration(primary) failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
     for id in displayIds {
       let bounds = CGDisplayBounds(id)
       let newX = Int32((bounds.origin.x + deltaX).rounded())
       let newY = Int32((bounds.origin.y + deltaY).rounded())
-      guard CGConfigureDisplayOrigin(config, id, newX, newY) == .success
-      else {
+      let originError = CGConfigureDisplayOrigin(config, id, newX, newY)
+      guard originError == .success else {
         CGCancelDisplayConfiguration(config)
-        return false
+        return setMacDisplayError(
+          "CGConfigureDisplayOrigin(primary \(id)) failed: \(macCGErrorDescription(originError))"
+        )
       }
     }
 
-    guard CGCompleteDisplayConfiguration(config, .forSession) == .success else {
-      return false
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "CGCompleteDisplayConfiguration(primary) failed: \(macCGErrorDescription(completeError))"
+      )
     }
-    return waitForMacMainDisplay(targetDisplayId)
+    guard waitForMacMainDisplay(targetDisplayId) else {
+      return setMacDisplayError(
+        "Timed out waiting for display \(targetDisplayId) to become main"
+      )
+    }
+    return true
   }
 
   private func setMacPrimaryDisplay(_ displayId: Int) -> Bool {
+    clearMacDisplayError()
     let targetDisplayId = CGDirectDisplayID(displayId)
     guard CGDisplayIsActive(targetDisplayId) != 0 else {
-      return false
+      return setMacDisplayError("Target display \(targetDisplayId) is not active")
     }
     return setMacMainDisplay(targetDisplayId, displayIds: activeMacDisplayIds())
   }
 
   private func setMacPrimaryDisplayOnly(_ displayId: Int) -> Bool {
+    clearMacDisplayError()
     let previousBackup = macDisplayConfigurationBackup
     func rollbackMacDisplayConfiguration() {
       let backup = previousBackup ?? macDisplayConfigurationBackup
@@ -817,9 +934,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
 
     let targetDisplayId = CGDirectDisplayID(displayId)
-    let displayIds = onlineMacDisplayIds()
+    let displayIds = allMacDisplayIds()
     guard displayIds.contains(targetDisplayId) else {
-      return false
+      return setMacDisplayError("Target display \(targetDisplayId) is unavailable")
     }
 
     guard
@@ -842,7 +959,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let activeIds = activeMacDisplayIds()
     guard activeIds.contains(targetDisplayId) else {
       rollbackMacDisplayConfiguration()
-      return false
+      return setMacDisplayError(
+        "Target display \(targetDisplayId) is not active after enabling"
+      )
     }
     guard unmirrorMacDisplays(activeIds) else {
       rollbackMacDisplayConfiguration()
@@ -854,35 +973,50 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
 
     var config: CGDisplayConfigRef?
-    guard sls.begin(&config) == .success, let config else {
+    let beginError = sls.begin(&config)
+    guard beginError == .success, let config else {
       rollbackMacDisplayConfiguration()
-      return false
+      return setMacDisplayError(
+        "SLSBeginDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
-    for id in onlineMacDisplayIds() {
+    for id in allMacDisplayIds() {
       let enable = id == targetDisplayId
-      if sls.configureEnabled(config, id, enable) != .success {
+      let enabledError = sls.configureEnabled(config, id, enable)
+      if enabledError != .success {
         CGCancelDisplayConfiguration(config)
         rollbackMacDisplayConfiguration()
-        return false
+        return setMacDisplayError(
+          "SLSConfigureDisplayEnabled(primary-only \(id), \(enable)) failed: \(macCGErrorDescription(enabledError))"
+        )
       }
-      if enable &&
-        sls.configureOrigin(config, id, 0, 0) != .success {
-        CGCancelDisplayConfiguration(config)
-        rollbackMacDisplayConfiguration()
-        return false
+      if enable {
+        let originError = sls.configureOrigin(config, id, 0, 0)
+        if originError != .success {
+          CGCancelDisplayConfiguration(config)
+          rollbackMacDisplayConfiguration()
+          return setMacDisplayError(
+            "SLSConfigureDisplayOrigin(primary-only \(id)) failed: \(macCGErrorDescription(originError))"
+          )
+        }
       }
     }
 
-    if sls.complete(config, .forSession, 0) != .success {
+    let completeError = sls.complete(config, .permanently, 0)
+    if completeError != .success {
       rollbackMacDisplayConfiguration()
-      return false
+      return setMacDisplayError(
+        "SLSCompleteDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(completeError))"
+      )
     }
 
     Thread.sleep(forTimeInterval: 0.5)
     guard waitForMacMainDisplay(targetDisplayId) else {
       rollbackMacDisplayConfiguration()
-      return false
+      return setMacDisplayError(
+        "Timed out waiting for display \(targetDisplayId) to remain main"
+      )
     }
     return true
   }
@@ -890,36 +1024,53 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private func restoreMacDisplayConfiguration(
     from backupOverride: [MacDisplayBackupItem]? = nil
   ) -> Bool {
+    if backupOverride == nil {
+      clearMacDisplayError()
+    }
     guard let backup = backupOverride ?? macDisplayConfigurationBackup else {
       return true
     }
     guard let sls = macSLSDisplayConfig else {
-      return false
+      return setMacDisplayError(
+        "SkyLight display configuration symbols are unavailable"
+      )
     }
 
     var config: CGDisplayConfigRef?
-    guard sls.begin(&config) == .success, let config else {
-      return false
+    let beginError = sls.begin(&config)
+    guard beginError == .success, let config else {
+      return setMacDisplayError(
+        "SLSBeginDisplayConfiguration(restore) failed: \(macCGErrorDescription(beginError))"
+      )
     }
 
     for item in backup {
-      guard sls.configureEnabled(config, item.displayId, true) == .success else {
-        return false
+      let enabledError = sls.configureEnabled(config, item.displayId, true)
+      guard enabledError == .success else {
+        CGCancelDisplayConfiguration(config)
+        return setMacDisplayError(
+          "SLSConfigureDisplayEnabled(restore \(item.displayId)) failed: \(macCGErrorDescription(enabledError))"
+        )
       }
-      guard
-        sls.configureOrigin(
-          config,
-          item.displayId,
-          Int32(item.origin.x.rounded()),
-          Int32(item.origin.y.rounded())
-        ) == .success
-      else {
-        return false
+      let originError = sls.configureOrigin(
+        config,
+        item.displayId,
+        Int32(item.origin.x.rounded()),
+        Int32(item.origin.y.rounded())
+      )
+      guard originError == .success else {
+        CGCancelDisplayConfiguration(config)
+        return setMacDisplayError(
+          "SLSConfigureDisplayOrigin(restore \(item.displayId)) failed: \(macCGErrorDescription(originError))"
+        )
       }
     }
 
-    guard sls.complete(config, .forSession, 0) == .success else {
-      return false
+    let completeError = sls.complete(config, .permanently, 0)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "SLSCompleteDisplayConfiguration(restore) failed: \(macCGErrorDescription(completeError))"
+      )
     }
 
     for item in backup {
@@ -932,19 +1083,19 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     if CGBeginDisplayConfiguration(&mirrorConfig) == .success,
       let mirrorConfig {
       for item in backup {
-        CGConfigureDisplayMirrorOfDisplay(
+        _ = CGConfigureDisplayMirrorOfDisplay(
           mirrorConfig,
           item.displayId,
           item.mirrorTarget == 0 ? kCGNullDirectDisplay : item.mirrorTarget
         )
-        CGConfigureDisplayOrigin(
+        _ = CGConfigureDisplayOrigin(
           mirrorConfig,
           item.displayId,
           Int32(item.origin.x.rounded()),
           Int32(item.origin.y.rounded())
         )
       }
-      _ = CGCompleteDisplayConfiguration(mirrorConfig, .forSession)
+      _ = CGCompleteDisplayConfiguration(mirrorConfig, .permanently)
     }
 
     if backupOverride == nil {
@@ -2090,6 +2241,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         let hasPending = self.macDisplayConfigurationBackup != nil
         DispatchQueue.main.async { result(hasPending) }
       }
+    case "getLastDisplayError":
+      macVirtualDisplayQueue.async {
+        let message = self.macLastVirtualDisplayError
+        DispatchQueue.main.async { result(message) }
+      }
     case "updateStaticMonitors":
       result(nil)
 #else
@@ -2127,6 +2283,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       result(false)
     case "hasPendingConfiguration":
       result(false)
+    case "getLastDisplayError":
+      result(nil)
     case "updateStaticMonitors":
       result(nil)
 #endif

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -532,14 +532,89 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     ) > 0
   }
 
-  private func setMacMirroring(_ enabled: Bool) -> Bool {
-    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: 32)
+  private func onlineMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
+    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: limit)
     var displayCount: UInt32 = 0
     guard
-      CGGetActiveDisplayList(UInt32(displayIds.count), &displayIds, &displayCount)
-        == .success,
-      displayCount >= 2
+      CGGetOnlineDisplayList(UInt32(displayIds.count), &displayIds, &displayCount)
+        == .success
     else {
+      return []
+    }
+    return Array(displayIds.prefix(Int(displayCount)))
+  }
+
+  private func unmirrorMacDisplays(_ displayIds: [CGDirectDisplayID]) -> Bool {
+    var config: CGDisplayConfigRef?
+    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
+      return false
+    }
+
+    for id in displayIds {
+      guard
+        CGConfigureDisplayMirrorOfDisplay(config, id, kCGNullDirectDisplay)
+          == .success
+      else {
+        CGCancelDisplayConfiguration(config)
+        return false
+      }
+    }
+    return CGCompleteDisplayConfiguration(config, .forSession) == .success
+  }
+
+  private func configureMacDisplayEnabled(
+    _ displayIds: [CGDirectDisplayID],
+    enabled: (CGDirectDisplayID) -> Bool
+  ) -> Bool {
+    guard let sls = macSLSDisplayConfig else {
+      return false
+    }
+
+    var config: CGDisplayConfigRef?
+    guard sls.begin(&config) == .success, let config else {
+      return false
+    }
+
+    for id in displayIds {
+      let shouldEnable = enabled(id)
+      guard sls.configureEnabled(config, id, shouldEnable) == .success else {
+        CGCancelDisplayConfiguration(config)
+        return false
+      }
+      if shouldEnable {
+        let bounds = CGDisplayBounds(id)
+        guard
+          sls.configureOrigin(
+            config,
+            id,
+            Int32(bounds.origin.x.rounded()),
+            Int32(bounds.origin.y.rounded())
+          ) == .success
+        else {
+          CGCancelDisplayConfiguration(config)
+          return false
+        }
+      }
+    }
+
+    return sls.complete(config, .forSession, 0) == .success
+  }
+
+  private func setMacExtendMode() -> Bool {
+    let displayIds = onlineMacDisplayIds()
+    guard !displayIds.isEmpty else {
+      return false
+    }
+    guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
+      return false
+    }
+    Thread.sleep(forTimeInterval: 0.3)
+
+    let activeIds = activeMacDisplayIds()
+    guard !activeIds.isEmpty else {
+      return false
+    }
+    guard unmirrorMacDisplays(activeIds) else {
       return false
     }
 
@@ -548,15 +623,99 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       return false
     }
 
-    let primary = displayIds[0]
-    for id in displayIds.prefix(Int(displayCount)).dropFirst() {
-      CGConfigureDisplayMirrorOfDisplay(
-        config,
-        id,
-        enabled ? primary : kCGNullDirectDisplay
-      )
+    let primary = activeIds.contains(CGMainDisplayID())
+      ? CGMainDisplayID()
+      : activeIds[0]
+    let orderedIds = [primary] + activeIds.filter { $0 != primary }
+
+    var nextX: Int32 = 0
+    for id in orderedIds {
+      let bounds = CGDisplayBounds(id)
+      guard CGConfigureDisplayOrigin(config, id, nextX, 0) == .success else {
+        CGCancelDisplayConfiguration(config)
+        return false
+      }
+      nextX += Int32(bounds.width.rounded())
     }
-    return CGCompleteDisplayConfiguration(config, .forAppOnly) == .success
+
+    guard CGCompleteDisplayConfiguration(config, .forSession) == .success else {
+      return false
+    }
+    macDisplayConfigurationBackup = nil
+    return true
+  }
+
+  private func setMacDuplicateMode() -> Bool {
+    let displayIds = onlineMacDisplayIds()
+    guard displayIds.count >= 2 else {
+      return false
+    }
+    guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
+      return false
+    }
+    Thread.sleep(forTimeInterval: 0.3)
+
+    let activeIds = activeMacDisplayIds()
+    guard activeIds.count >= 2 else {
+      return false
+    }
+    let primary = activeIds.contains(CGMainDisplayID())
+      ? CGMainDisplayID()
+      : activeIds[0]
+
+    var config: CGDisplayConfigRef?
+    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
+      return false
+    }
+
+    for id in activeIds where id != primary {
+      guard CGConfigureDisplayMirrorOfDisplay(config, id, primary) == .success
+      else {
+        CGCancelDisplayConfiguration(config)
+        return false
+      }
+    }
+
+    guard CGCompleteDisplayConfiguration(config, .forSession) == .success else {
+      return false
+    }
+    macDisplayConfigurationBackup = nil
+    return true
+  }
+
+  private func setMacSingleDisplayMode(at index: Int) -> Bool {
+    let displayIds = onlineMacDisplayIds()
+    guard displayIds.indices.contains(index) else {
+      return false
+    }
+    return setMacPrimaryDisplayOnly(Int(displayIds[index]))
+  }
+
+  private func getCurrentMacMultiDisplayMode() -> Int {
+    let activeIds = activeMacDisplayIds()
+    let onlineIds = onlineMacDisplayIds()
+    guard !activeIds.isEmpty else {
+      return 4
+    }
+    if activeIds.count <= 1 {
+      guard let activeId = activeIds.first,
+        let index = onlineIds.firstIndex(of: activeId)
+      else {
+        return 1
+      }
+      return index == 1 ? 2 : 1
+    }
+
+    let mirroredCount = activeIds.filter { id in
+      CGDisplayMirrorsDisplay(id) != 0 || CGDisplayIsInMirrorSet(id) != 0
+    }.count
+    if mirroredCount > 0 {
+      return 3
+    }
+    if activeIds.count == onlineIds.count {
+      return 0
+    }
+    return 4
   }
 
   private func activeMacDisplayIds(limit: Int = 32) -> [CGDirectDisplayID] {
@@ -571,8 +730,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return Array(displayIds.prefix(Int(displayCount)))
   }
 
-  private func saveMacDisplayConfiguration() -> Bool {
-    let displayIds = activeMacDisplayIds()
+  private func saveMacDisplayConfiguration(
+    displayIds inputDisplayIds: [CGDirectDisplayID]? = nil
+  ) -> Bool {
+    let displayIds = inputDisplayIds ?? activeMacDisplayIds()
     guard !displayIds.isEmpty else {
       return false
     }
@@ -646,30 +807,48 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func setMacPrimaryDisplayOnly(_ displayId: Int) -> Bool {
+    let previousBackup = macDisplayConfigurationBackup
     func rollbackMacDisplayConfiguration() {
-      let backup = macDisplayConfigurationBackup
+      let backup = previousBackup ?? macDisplayConfigurationBackup
       macDisplayConfigurationBackup = nil
       if backup != nil {
         _ = restoreMacDisplayConfiguration(from: backup)
       }
     }
 
-    guard macDisplayConfigurationBackup == nil else {
-      return false
-    }
-    guard macVirtualDisplayIdsSnapshot().contains(displayId) else {
-      return false
-    }
     let targetDisplayId = CGDirectDisplayID(displayId)
-    guard CGDisplayIsActive(targetDisplayId) != 0 else {
+    let displayIds = onlineMacDisplayIds()
+    guard displayIds.contains(targetDisplayId) else {
       return false
     }
-    let displayIds = activeMacDisplayIds()
-    guard saveMacDisplayConfiguration(), let sls = macSLSDisplayConfig else {
+
+    guard
+      (macDisplayConfigurationBackup != nil ||
+        saveMacDisplayConfiguration(displayIds: displayIds)),
+      let sls = macSLSDisplayConfig
+    else {
       rollbackMacDisplayConfiguration()
       return false
     }
-    guard setMacMainDisplay(targetDisplayId, displayIds: displayIds) else {
+
+    guard configureMacDisplayEnabled(displayIds, enabled: { id in
+      id == targetDisplayId || CGDisplayIsActive(id) != 0
+    }) else {
+      rollbackMacDisplayConfiguration()
+      return false
+    }
+    Thread.sleep(forTimeInterval: 0.3)
+
+    let activeIds = activeMacDisplayIds()
+    guard activeIds.contains(targetDisplayId) else {
+      rollbackMacDisplayConfiguration()
+      return false
+    }
+    guard unmirrorMacDisplays(activeIds) else {
+      rollbackMacDisplayConfiguration()
+      return false
+    }
+    guard setMacMainDisplay(targetDisplayId, displayIds: activeIds) else {
       rollbackMacDisplayConfiguration()
       return false
     }
@@ -680,7 +859,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       return false
     }
 
-    for id in displayIds {
+    for id in onlineMacDisplayIds() {
       let enable = id == targetDisplayId
       if sls.configureEnabled(config, id, enable) != .success {
         CGCancelDisplayConfiguration(config)
@@ -1876,25 +2055,24 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     case "setMultiDisplayMode":
       let args = call.arguments as? [String: Any]
       let mode = args?["mode"] as? Int ?? 4
-      switch mode {
-      case 0:
-        result(setMacMirroring(false))
-      case 3:
-        result(setMacMirroring(true))
-      default:
-        result(false)
+      macVirtualDisplayQueue.async {
+        let ok: Bool
+        switch mode {
+        case 0:
+          ok = self.setMacExtendMode()
+        case 1:
+          ok = self.setMacSingleDisplayMode(at: 0)
+        case 2:
+          ok = self.setMacSingleDisplayMode(at: 1)
+        case 3:
+          ok = self.setMacDuplicateMode()
+        default:
+          ok = false
+        }
+        DispatchQueue.main.async { result(ok) }
       }
     case "getCurrentMultiDisplayMode":
-      let displays = macDisplayList()
-      if displays.count <= 1 {
-        result(1)
-      } else {
-        let anyMirrored = displays.contains { item in
-          guard let uid = item["displayUid"] as? Int else { return false }
-          return CGDisplayMirrorsDisplay(CGDirectDisplayID(uid)) != 0
-        }
-        result(anyMirrored ? 3 : 0)
-      }
+      result(getCurrentMacMultiDisplayMode())
     case "setPrimaryDisplayOnly":
       let args = call.arguments as? [String: Any]
       let displayUid = args?["displayUid"] as? Int ?? -1

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -83,36 +83,19 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private struct MacSLSDisplayConfig {
-    typealias BeginFn = @convention(c) (
-      UnsafeMutablePointer<CGDisplayConfigRef?>
-    ) -> CGError
     typealias ConfigureEnabledFn = @convention(c) (
       CGDisplayConfigRef?,
       CGDirectDisplayID,
       Bool
-    ) -> CGError
-    typealias ConfigureOriginFn = @convention(c) (
-      CGDisplayConfigRef?,
-      CGDirectDisplayID,
-      Int32,
-      Int32
     ) -> CGError
     typealias GetDisplayListFn = @convention(c) (
       UInt32,
       UnsafeMutablePointer<CGDirectDisplayID>?,
       UnsafeMutablePointer<UInt32>?
     ) -> CGError
-    typealias CompleteFn = @convention(c) (
-      CGDisplayConfigRef?,
-      CGConfigureOption,
-      UInt32
-    ) -> CGError
 
-    let begin: BeginFn
     let configureEnabled: ConfigureEnabledFn
-    let configureOrigin: ConfigureOriginFn
     let getDisplayList: GetDisplayListFn
-    let complete: CompleteFn
 
     static func load(
       using loadSkyLight: () -> UnsafeMutableRawPointer?
@@ -129,32 +112,20 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
 
       guard
-        let begin = symbol("SLSBeginDisplayConfiguration", as: BeginFn.self),
         let configureEnabled = symbol(
           "SLSConfigureDisplayEnabled",
           as: ConfigureEnabledFn.self
-        ),
-        let configureOrigin = symbol(
-          "SLSConfigureDisplayOrigin",
-          as: ConfigureOriginFn.self
-        ),
+        ) ?? symbol("CGSConfigureDisplayEnabled", as: ConfigureEnabledFn.self),
         let getDisplayList =
           symbol("SLSGetDisplayList", as: GetDisplayListFn.self)
-          ?? symbol("CGSGetDisplayList", as: GetDisplayListFn.self),
-        let complete = symbol(
-          "SLSCompleteDisplayConfiguration",
-          as: CompleteFn.self
-        )
+          ?? symbol("CGSGetDisplayList", as: GetDisplayListFn.self)
       else {
         return nil
       }
 
       return MacSLSDisplayConfig(
-        begin: begin,
         configureEnabled: configureEnabled,
-        configureOrigin: configureOrigin,
-        getDisplayList: getDisplayList,
-        complete: complete
+        getDisplayList: getDisplayList
       )
     }
   }
@@ -445,21 +416,15 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func macDisplayList() -> [[String: Any]] {
-    var displayIds = Array<CGDirectDisplayID>(repeating: 0, count: 32)
-    var displayCount: UInt32 = 0
-    let err = CGGetActiveDisplayList(
-      UInt32(displayIds.count),
-      &displayIds,
-      &displayCount
-    )
-    guard err == .success else {
+    let displayIds = enabledMacDisplayIds()
+    guard !displayIds.isEmpty else {
       return []
     }
 
     let names = screenNameByDisplayId()
     let mainId = Int(CGMainDisplayID())
     let virtualDisplayIds = macVirtualDisplayIdsSnapshot()
-    return displayIds.prefix(Int(displayCount)).enumerated().map { index, id in
+    return displayIds.enumerated().map { index, id in
       let displayId = Int(id)
       let mode = CGDisplayCopyDisplayMode(id)
       let bounds = CGDisplayBounds(id)
@@ -475,7 +440,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         "isVirtual": isVirtual,
         "displayName": name,
         "deviceName": "\(displayId)",
-        "active": CGDisplayIsActive(id) != 0,
+        "active": isMacDisplayEnabled(id),
         "displayUid": displayId,
         "orientation": 0,
         "left": Int(bounds.minX.rounded()),
@@ -578,6 +543,15 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return Array(displayIds.prefix(min(Int(displayCount), displayIds.count)))
   }
 
+  private func isMacDisplayEnabled(_ displayId: CGDirectDisplayID) -> Bool {
+    return CGDisplayIsActive(displayId) != 0 ||
+      CGDisplayIsInMirrorSet(displayId) != 0
+  }
+
+  private func enabledMacDisplayIds() -> [CGDirectDisplayID] {
+    return allMacDisplayIds().filter(isMacDisplayEnabled)
+  }
+
   private func unmirrorMacDisplays(_ displayIds: [CGDirectDisplayID]) -> Bool {
     var config: CGDisplayConfigRef?
     let beginError = CGBeginDisplayConfiguration(&config)
@@ -633,10 +607,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
 
     var config: CGDisplayConfigRef?
-    let beginError = sls.begin(&config)
+    let beginError = CGBeginDisplayConfiguration(&config)
     guard beginError == .success, let config else {
       return setMacDisplayError(
-        "SLSBeginDisplayConfiguration failed: \(macCGErrorDescription(beginError))"
+        "CGBeginDisplayConfiguration(enable) failed: \(macCGErrorDescription(beginError))"
       )
     }
 
@@ -651,7 +625,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
       if shouldEnable {
         let bounds = CGDisplayBounds(id)
-        let originError = sls.configureOrigin(
+        let originError = CGConfigureDisplayOrigin(
           config,
           id,
           Int32(bounds.origin.x.rounded()),
@@ -660,16 +634,16 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         guard originError == .success else {
           CGCancelDisplayConfiguration(config)
           return setMacDisplayError(
-            "SLSConfigureDisplayOrigin(\(id)) failed: \(macCGErrorDescription(originError))"
+            "CGConfigureDisplayOrigin(enable \(id)) failed: \(macCGErrorDescription(originError))"
           )
         }
       }
     }
 
-    let completeError = sls.complete(config, .permanently, 0)
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
     guard completeError == .success else {
       return setMacDisplayError(
-        "SLSCompleteDisplayConfiguration(enable) failed: \(macCGErrorDescription(completeError))"
+        "CGCompleteDisplayConfiguration(enable) failed: \(macCGErrorDescription(completeError))"
       )
     }
     return true
@@ -775,6 +749,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         "CGCompleteDisplayConfiguration(duplicate) failed: \(macCGErrorDescription(completeError))"
       )
     }
+    guard waitForMacDuplicateTopology(primary, expectedDisplayIds: activeIds) else {
+      let mirrors = enabledMacDisplayIds().map {
+        "\($0)->\(CGDisplayMirrorsDisplay($0))"
+      }.joined(separator: ",")
+      return setMacDisplayError(
+        "Timed out waiting for duplicate topology; mirrors: [\(mirrors)]"
+      )
+    }
     macDisplayConfigurationBackup = nil
     return true
   }
@@ -789,14 +771,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func getCurrentMacMultiDisplayMode() -> Int {
-    let activeIds = activeMacDisplayIds()
-    guard !activeIds.isEmpty else {
+    let displayIds = macDisplayConfigurationBackup?.map { $0.displayId }
+      ?? allMacDisplayIds()
+    let enabledIds = displayIds.filter(isMacDisplayEnabled)
+    guard !enabledIds.isEmpty else {
       return 4
     }
-    if activeIds.count <= 1 {
-      let displayIds = macDisplayConfigurationBackup?.map { $0.displayId }
-        ?? allMacDisplayIds()
-      guard let activeId = activeIds.first,
+    if enabledIds.count <= 1 {
+      guard let activeId = enabledIds.first,
         let index = displayIds.firstIndex(of: activeId)
       else {
         return 1
@@ -804,8 +786,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       return index == 1 ? 2 : 1
     }
 
-    let mirroredCount = activeIds.filter { id in
-      CGDisplayMirrorsDisplay(id) != 0 || CGDisplayIsInMirrorSet(id) != 0
+    let mirroredCount = enabledIds.filter { id in
+      CGDisplayMirrorsDisplay(id) != 0
     }.count
     if mirroredCount > 0 {
       return 3
@@ -870,8 +852,32 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   ) -> Bool {
     let deadline = Date().addingTimeInterval(timeout)
     repeat {
-      let activeIds = activeMacDisplayIds()
-      if activeIds.count == 1 && activeIds.first == displayId {
+      let enabledIds = enabledMacDisplayIds()
+      if enabledIds.count == 1 && enabledIds.first == displayId {
+        return true
+      }
+      Thread.sleep(forTimeInterval: 0.1)
+    } while Date() < deadline
+    return false
+  }
+
+  private func waitForMacDuplicateTopology(
+    _ primaryDisplayId: CGDirectDisplayID,
+    expectedDisplayIds: [CGDirectDisplayID],
+    timeout: TimeInterval = 1.5
+  ) -> Bool {
+    let expected = Set(expectedDisplayIds)
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      let enabledIds = enabledMacDisplayIds()
+      let enabled = Set(enabledIds)
+      let allExpectedEnabled = expected.isSubset(of: enabled)
+      let mirroredDisplays = enabledIds.filter { id in
+        id != primaryDisplayId && CGDisplayMirrorsDisplay(id) == primaryDisplayId
+      }
+      if enabled.contains(primaryDisplayId),
+        allExpectedEnabled,
+        mirroredDisplays.count == enabledIds.count - 1 {
         return true
       }
       Thread.sleep(forTimeInterval: 0.1)
@@ -954,11 +960,16 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
     guard
       (macDisplayConfigurationBackup != nil ||
-        saveMacDisplayConfiguration(displayIds: displayIds)),
-      let sls = macSLSDisplayConfig
+        saveMacDisplayConfiguration(displayIds: displayIds))
     else {
       rollbackMacDisplayConfiguration()
       return false
+    }
+    guard let sls = macSLSDisplayConfig else {
+      rollbackMacDisplayConfiguration()
+      return setMacDisplayError(
+        "SkyLight display configuration symbols are unavailable"
+      )
     }
 
     guard configureMacDisplayEnabled(displayIds, enabled: { id in
@@ -986,11 +997,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
 
     var config: CGDisplayConfigRef?
-    let beginError = sls.begin(&config)
+    let beginError = CGBeginDisplayConfiguration(&config)
     guard beginError == .success, let config else {
       rollbackMacDisplayConfiguration()
       return setMacDisplayError(
-        "SLSBeginDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(beginError))"
+        "CGBeginDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(beginError))"
       )
     }
 
@@ -1005,22 +1016,22 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         )
       }
       if enable {
-        let originError = sls.configureOrigin(config, id, 0, 0)
+        let originError = CGConfigureDisplayOrigin(config, id, 0, 0)
         if originError != .success {
           CGCancelDisplayConfiguration(config)
           rollbackMacDisplayConfiguration()
           return setMacDisplayError(
-            "SLSConfigureDisplayOrigin(primary-only \(id)) failed: \(macCGErrorDescription(originError))"
+            "CGConfigureDisplayOrigin(primary-only \(id)) failed: \(macCGErrorDescription(originError))"
           )
         }
       }
     }
 
-    let completeError = sls.complete(config, .permanently, 0)
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
     if completeError != .success {
       rollbackMacDisplayConfiguration()
       return setMacDisplayError(
-        "SLSCompleteDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(completeError))"
+        "CGCompleteDisplayConfiguration(primary-only) failed: \(macCGErrorDescription(completeError))"
       )
     }
 
@@ -1057,10 +1068,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
 
     var config: CGDisplayConfigRef?
-    let beginError = sls.begin(&config)
+    let beginError = CGBeginDisplayConfiguration(&config)
     guard beginError == .success, let config else {
       return setMacDisplayError(
-        "SLSBeginDisplayConfiguration(restore) failed: \(macCGErrorDescription(beginError))"
+        "CGBeginDisplayConfiguration(restore) failed: \(macCGErrorDescription(beginError))"
       )
     }
 
@@ -1072,7 +1083,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           "SLSConfigureDisplayEnabled(restore \(item.displayId)) failed: \(macCGErrorDescription(enabledError))"
         )
       }
-      let originError = sls.configureOrigin(
+      let originError = CGConfigureDisplayOrigin(
         config,
         item.displayId,
         Int32(item.origin.x.rounded()),
@@ -1081,15 +1092,15 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       guard originError == .success else {
         CGCancelDisplayConfiguration(config)
         return setMacDisplayError(
-          "SLSConfigureDisplayOrigin(restore \(item.displayId)) failed: \(macCGErrorDescription(originError))"
+          "CGConfigureDisplayOrigin(restore \(item.displayId)) failed: \(macCGErrorDescription(originError))"
         )
       }
     }
 
-    let completeError = sls.complete(config, .permanently, 0)
+    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
     guard completeError == .success else {
       return setMacDisplayError(
-        "SLSCompleteDisplayConfiguration(restore) failed: \(macCGErrorDescription(completeError))"
+        "CGCompleteDisplayConfiguration(restore) failed: \(macCGErrorDescription(completeError))"
       )
     }
 

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -589,7 +589,63 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return true
   }
 
+  private func waitForMacMainDisplay(
+    _ displayId: CGDirectDisplayID,
+    timeout: TimeInterval = 1
+  ) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      if CGMainDisplayID() == displayId || CGDisplayIsMain(displayId) != 0 {
+        return true
+      }
+      Thread.sleep(forTimeInterval: 0.1)
+    } while Date() < deadline
+    return false
+  }
+
+  private func setMacMainDisplay(
+    _ targetDisplayId: CGDirectDisplayID,
+    displayIds: [CGDirectDisplayID]
+  ) -> Bool {
+    guard displayIds.contains(targetDisplayId) else {
+      return false
+    }
+
+    let targetBounds = CGDisplayBounds(targetDisplayId)
+    let deltaX = -targetBounds.origin.x
+    let deltaY = -targetBounds.origin.y
+
+    var config: CGDisplayConfigRef?
+    guard CGBeginDisplayConfiguration(&config) == .success, let config else {
+      return false
+    }
+
+    for id in displayIds {
+      let bounds = CGDisplayBounds(id)
+      let newX = Int32((bounds.origin.x + deltaX).rounded())
+      let newY = Int32((bounds.origin.y + deltaY).rounded())
+      guard CGConfigureDisplayOrigin(config, id, newX, newY) == .success
+      else {
+        CGCancelDisplayConfiguration(config)
+        return false
+      }
+    }
+
+    guard CGCompleteDisplayConfiguration(config, .forSession) == .success else {
+      return false
+    }
+    return waitForMacMainDisplay(targetDisplayId)
+  }
+
   private func setMacPrimaryDisplayOnly(_ displayId: Int) -> Bool {
+    func rollbackMacDisplayConfiguration() {
+      let backup = macDisplayConfigurationBackup
+      macDisplayConfigurationBackup = nil
+      if backup != nil {
+        _ = restoreMacDisplayConfiguration(from: backup)
+      }
+    }
+
     guard macDisplayConfigurationBackup == nil else {
       return false
     }
@@ -600,41 +656,47 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     guard CGDisplayIsActive(targetDisplayId) != 0 else {
       return false
     }
+    let displayIds = activeMacDisplayIds()
     guard saveMacDisplayConfiguration(), let sls = macSLSDisplayConfig else {
-      macDisplayConfigurationBackup = nil
+      rollbackMacDisplayConfiguration()
+      return false
+    }
+    guard setMacMainDisplay(targetDisplayId, displayIds: displayIds) else {
+      rollbackMacDisplayConfiguration()
       return false
     }
 
     var config: CGDisplayConfigRef?
     guard sls.begin(&config) == .success, let config else {
-      macDisplayConfigurationBackup = nil
+      rollbackMacDisplayConfiguration()
       return false
     }
 
-    let displayIds = activeMacDisplayIds()
     for id in displayIds {
       let enable = id == targetDisplayId
       if sls.configureEnabled(config, id, enable) != .success {
-        macDisplayConfigurationBackup = nil
+        CGCancelDisplayConfiguration(config)
+        rollbackMacDisplayConfiguration()
         return false
       }
       if enable &&
         sls.configureOrigin(config, id, 0, 0) != .success {
-        macDisplayConfigurationBackup = nil
+        CGCancelDisplayConfiguration(config)
+        rollbackMacDisplayConfiguration()
         return false
       }
     }
 
     if sls.complete(config, .forSession, 0) != .success {
-      let backup = macDisplayConfigurationBackup
-      macDisplayConfigurationBackup = nil
-      if backup != nil {
-        _ = restoreMacDisplayConfiguration(from: backup)
-      }
+      rollbackMacDisplayConfiguration()
       return false
     }
 
     Thread.sleep(forTimeInterval: 0.5)
+    guard waitForMacMainDisplay(targetDisplayId) else {
+      rollbackMacDisplayConfiguration()
+      return false
+    }
     return true
   }
 

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -42,9 +42,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var macDisplayConfigurationBackup: [MacDisplayBackupItem]? = nil
   private var macLastVirtualDisplayError: String? = nil
   private var macSkyLightHandle: UnsafeMutableRawPointer?
+  private var macTerminationObserver: NSObjectProtocol?
   private lazy var macSLSDisplayConfig = MacSLSDisplayConfig.load(
     using: { [weak self] in self?.loadMacSkyLight() }
   )
+  private let macVirtualDisplaySerialBase = 0x4350_5600
+  private let macVirtualDisplaySerialMax = 0x4350_56ff
   private let macCustomDisplayConfigsKey =
     "com.cloudplayplus.hardware_simulator.macos.custom_display_configs"
   private let macHelperName = "cloudplayplus_vd_helper"
@@ -55,15 +58,22 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let instance = HardwareSimulatorPlugin()
     instance.methodChannel = channel
     instance.defaultCursorHasher = CursorHasher()
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    instance.registerMacTerminationObserver()
+#endif
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
-#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   deinit {
-    _ = restoreMacDisplayConfiguration()
-    terminateAllMacVirtualDisplays()
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    if let macTerminationObserver {
+      NotificationCenter.default.removeObserver(macTerminationObserver)
+    }
+    restoreMacDisplaysBeforeExit()
+#endif
   }
 
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   override init() {
     super.init()
     macVirtualDisplayQueue.setSpecific(key: macVirtualDisplayQueueKey, value: ())
@@ -150,11 +160,44 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return "CGError(\(error.rawValue))"
   }
 
+  private func completeMacDisplayConfiguration(
+    _ config: CGDisplayConfigRef,
+    reason: String
+  ) -> Bool {
+    let completeError = CGCompleteDisplayConfiguration(config, .forSession)
+    guard completeError == .success else {
+      return setMacDisplayError(
+        "CGCompleteDisplayConfiguration(\(reason)) failed: \(macCGErrorDescription(completeError))"
+      )
+    }
+    return true
+  }
+
   @discardableResult
   private func setMacDisplayError(_ message: String) -> Bool {
     macLastVirtualDisplayError = message
     NSLog("CloudPlayPlus macOS display: %@", message)
     return false
+  }
+
+  private func registerMacTerminationObserver() {
+    guard macTerminationObserver == nil else {
+      return
+    }
+    macTerminationObserver = NotificationCenter.default.addObserver(
+      forName: NSApplication.willTerminateNotification,
+      object: nil,
+      queue: nil
+    ) { [weak self] _ in
+      self?.restoreMacDisplaysBeforeExit()
+    }
+  }
+
+  private func restoreMacDisplaysBeforeExit() {
+    if macDisplayConfigurationBackup != nil {
+      _ = restoreMacDisplayConfiguration()
+    }
+    terminateAllMacVirtualDisplays()
   }
 
   private func macHelperURL() -> URL? {
@@ -283,14 +326,13 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func nextMacVirtualDisplaySerial() -> Int {
     let usedSerials = Set(macVirtualDisplaySerials.values)
-    let serialBase = 0x4350_5600
     for slot in 1...255 {
-      let serial = serialBase + slot
+      let serial = macVirtualDisplaySerialBase + slot
       if !usedSerials.contains(serial) {
         return serial
       }
     }
-    return serialBase + macVirtualDisplaySerials.count + 1
+    return macVirtualDisplaySerialBase + macVirtualDisplaySerials.count + 1
   }
 
   private func spawnMacVirtualDisplay(
@@ -552,6 +594,28 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return allMacDisplayIds().filter(isMacDisplayEnabled)
   }
 
+  private func isMacCloudPlayVirtualDisplay(_ displayId: CGDirectDisplayID) -> Bool {
+    let serial = Int(CGDisplaySerialNumber(displayId))
+    return macVirtualDisplayIdsSnapshot().contains(Int(displayId)) ||
+      (serial > macVirtualDisplaySerialBase && serial <= macVirtualDisplaySerialMax)
+  }
+
+  private func isMacDisplayEnableCandidate(_ displayId: CGDirectDisplayID) -> Bool {
+    if CGDisplayIsBuiltin(displayId) != 0 || isMacDisplayEnabled(displayId) {
+      return true
+    }
+    if isMacCloudPlayVirtualDisplay(displayId) {
+      return macVirtualDisplayIdsSnapshot().contains(Int(displayId))
+    }
+    return CGDisplayVendorNumber(displayId) != 0 ||
+      CGDisplayModelNumber(displayId) != 0 ||
+      CGDisplaySerialNumber(displayId) != 0
+  }
+
+  private func enableableMacDisplayIds() -> [CGDirectDisplayID] {
+    return allMacDisplayIds().filter(isMacDisplayEnableCandidate)
+  }
+
   private func unmirrorMacDisplays(_ displayIds: [CGDirectDisplayID]) -> Bool {
     var config: CGDisplayConfigRef?
     let beginError = CGBeginDisplayConfiguration(&config)
@@ -587,13 +651,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       return true
     }
 
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    guard completeError == .success else {
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(unmirror) failed: \(macCGErrorDescription(completeError))"
-      )
-    }
-    return true
+    return completeMacDisplayConfiguration(config, reason: "unmirror")
   }
 
   private func configureMacDisplayEnabled(
@@ -628,18 +686,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
     }
 
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    guard completeError == .success else {
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(enable) failed: \(macCGErrorDescription(completeError))"
-      )
-    }
-    return true
+    return completeMacDisplayConfiguration(config, reason: "enable")
   }
 
   private func setMacExtendMode() -> Bool {
     clearMacDisplayError()
-    let displayIds = allMacDisplayIds()
+    let displayIds = enableableMacDisplayIds()
     guard !displayIds.isEmpty else {
       return setMacDisplayError("No displays found for extend mode")
     }
@@ -682,11 +734,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       nextX += Int32(bounds.width.rounded())
     }
 
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    guard completeError == .success else {
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(extend) failed: \(macCGErrorDescription(completeError))"
-      )
+    guard completeMacDisplayConfiguration(config, reason: "extend") else {
+      return false
     }
     macDisplayConfigurationBackup = nil
     return true
@@ -694,7 +743,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func setMacDuplicateMode() -> Bool {
     clearMacDisplayError()
-    let displayIds = allMacDisplayIds()
+    let displayIds = enableableMacDisplayIds()
     guard displayIds.count >= 2 else {
       return setMacDisplayError("Duplicate mode needs at least two displays")
     }
@@ -731,11 +780,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
     }
 
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    guard completeError == .success else {
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(duplicate) failed: \(macCGErrorDescription(completeError))"
-      )
+    guard completeMacDisplayConfiguration(config, reason: "duplicate") else {
+      return false
     }
     guard waitForMacDuplicateTopology(primary, expectedDisplayIds: activeIds) else {
       let mirrors = enabledMacDisplayIds().map {
@@ -751,7 +797,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func setMacSingleDisplayMode(at index: Int) -> Bool {
     clearMacDisplayError()
-    let displayIds = allMacDisplayIds()
+    let displayIds = enableableMacDisplayIds()
     guard displayIds.indices.contains(index) else {
       return setMacDisplayError("Display index \(index) is unavailable")
     }
@@ -906,11 +952,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
     }
 
-    let completeError = CGCompleteDisplayConfiguration(config, .permanently)
-    guard completeError == .success else {
-      return setMacDisplayError(
-        "CGCompleteDisplayConfiguration(primary) failed: \(macCGErrorDescription(completeError))"
-      )
+    guard completeMacDisplayConfiguration(config, reason: "primary") else {
+      return false
     }
     guard waitForMacMainDisplay(targetDisplayId) else {
       return setMacDisplayError(
@@ -941,14 +984,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     }
 
     let targetDisplayId = CGDirectDisplayID(displayId)
-    let displayIds = allMacDisplayIds()
+    let displayIds = enableableMacDisplayIds()
     guard displayIds.contains(targetDisplayId) else {
       return setMacDisplayError("Target display \(targetDisplayId) is unavailable")
     }
 
     guard
       (macDisplayConfigurationBackup != nil ||
-        saveMacDisplayConfiguration(displayIds: displayIds))
+        saveMacDisplayConfiguration(displayIds: displayIds.filter(isMacDisplayEnabled)))
     else {
       rollbackMacDisplayConfiguration()
       return false
@@ -1001,6 +1044,42 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return true
   }
 
+  private func restoreMacDefaultDisplayConfiguration() -> Bool {
+    let displayIds = enableableMacDisplayIds()
+    guard !displayIds.isEmpty else {
+      return setMacDisplayError("No displays found for default restore")
+    }
+    guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
+      return false
+    }
+    Thread.sleep(forTimeInterval: 0.3)
+
+    let activeIds = activeMacDisplayIds()
+    guard !activeIds.isEmpty else {
+      return setMacDisplayError("No active displays after default restore")
+    }
+    guard unmirrorMacDisplays(activeIds) else {
+      return false
+    }
+
+    let virtualDisplayIds = macVirtualDisplayIdsSnapshot()
+    let preferredMainDisplayId: CGDirectDisplayID
+    if let builtInDisplayId = activeIds.first(where: { CGDisplayIsBuiltin($0) != 0 }) {
+      preferredMainDisplayId = builtInDisplayId
+    } else if let physicalDisplayId = activeIds.first(
+      where: { !virtualDisplayIds.contains(Int($0)) }
+    ) {
+      preferredMainDisplayId = physicalDisplayId
+    } else {
+      preferredMainDisplayId = activeIds[0]
+    }
+    guard setMacMainDisplay(preferredMainDisplayId, displayIds: activeIds) else {
+      return false
+    }
+    macDisplayConfigurationBackup = nil
+    return true
+  }
+
   private func restoreMacDisplayConfiguration(
     from backupOverride: [MacDisplayBackupItem]? = nil
   ) -> Bool {
@@ -1008,38 +1087,75 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       clearMacDisplayError()
     }
     guard let backup = backupOverride ?? macDisplayConfigurationBackup else {
-      return true
+      return restoreMacDefaultDisplayConfiguration()
     }
-    let displayIds = backup.map { $0.displayId }
+    let restorableBackup = backup.filter { item in
+      isMacDisplayEnableCandidate(item.displayId)
+    }
+    guard !restorableBackup.isEmpty else {
+      return restoreMacDefaultDisplayConfiguration()
+    }
 
-    guard configureMacDisplayEnabled(displayIds, enabled: { _ in true }) else {
+    let displayIds = restorableBackup.map { $0.displayId }
+    let displayIdSet = Set(displayIds)
+    let restoredMainDisplayId = restorableBackup.first { item in
+      abs(item.origin.x) < 1 && abs(item.origin.y) < 1
+    }?.displayId ?? restorableBackup.first?.displayId
+
+    guard configureMacDisplayEnabled(allMacDisplayIds(), enabled: { id in
+      displayIdSet.contains(id)
+    }) else {
       return false
     }
     Thread.sleep(forTimeInterval: 0.3)
 
-    for item in backup {
+    for item in restorableBackup {
       if let mode = item.mode {
         _ = CGDisplaySetDisplayMode(item.displayId, mode, nil)
       }
     }
 
     var mirrorConfig: CGDisplayConfigRef?
-    if CGBeginDisplayConfiguration(&mirrorConfig) == .success,
-      let mirrorConfig {
-      for item in backup {
-        _ = CGConfigureDisplayMirrorOfDisplay(
-          mirrorConfig,
-          item.displayId,
-          item.mirrorTarget == 0 ? kCGNullDirectDisplay : item.mirrorTarget
-        )
-        _ = CGConfigureDisplayOrigin(
-          mirrorConfig,
-          item.displayId,
-          Int32(item.origin.x.rounded()),
-          Int32(item.origin.y.rounded())
+    let beginError = CGBeginDisplayConfiguration(&mirrorConfig)
+    guard beginError == .success, let mirrorConfig else {
+      return setMacDisplayError(
+        "CGBeginDisplayConfiguration(restore layout) failed: \(macCGErrorDescription(beginError))"
+      )
+    }
+    for item in restorableBackup {
+      let mirrorError = CGConfigureDisplayMirrorOfDisplay(
+        mirrorConfig,
+        item.displayId,
+        item.mirrorTarget == 0 ? kCGNullDirectDisplay : item.mirrorTarget
+      )
+      guard mirrorError == .success else {
+        CGCancelDisplayConfiguration(mirrorConfig)
+        return setMacDisplayError(
+          "CGConfigureDisplayMirrorOfDisplay(restore \(item.displayId)) failed: \(macCGErrorDescription(mirrorError))"
         )
       }
-      _ = CGCompleteDisplayConfiguration(mirrorConfig, .permanently)
+      let originError = CGConfigureDisplayOrigin(
+        mirrorConfig,
+        item.displayId,
+        Int32(item.origin.x.rounded()),
+        Int32(item.origin.y.rounded())
+      )
+      guard originError == .success else {
+        CGCancelDisplayConfiguration(mirrorConfig)
+        return setMacDisplayError(
+          "CGConfigureDisplayOrigin(restore \(item.displayId)) failed: \(macCGErrorDescription(originError))"
+        )
+      }
+    }
+    guard completeMacDisplayConfiguration(mirrorConfig, reason: "restore layout") else {
+      return false
+    }
+
+    if let restoredMainDisplayId,
+      !waitForMacMainDisplay(restoredMainDisplayId, timeout: 1.5) {
+      return setMacDisplayError(
+        "Timed out waiting for restored main display \(restoredMainDisplayId)"
+      )
     }
 
     if backupOverride == nil {

--- a/macos/VirtualDisplayHelper/CloudPlayPlusVirtualDisplayHelper.m
+++ b/macos/VirtualDisplayHelper/CloudPlayPlusVirtualDisplayHelper.m
@@ -187,10 +187,16 @@ int main(int argc, const char *argv[]) {
     int height = 0;
     int refreshRate = 0;
     int parentPIDInt = 0;
+    int serialNum = 0x43505601;
     if (!parsePositiveInt(argv[1], &width) ||
         !parsePositiveInt(argv[2], &height) ||
         !parsePositiveInt(argv[3], &refreshRate) ||
         !parsePositiveInt(argv[4], &parentPIDInt)) {
+      fprintf(stdout, "0\n");
+      fflush(stdout);
+      return 1;
+    }
+    if (argc >= 6 && !parsePositiveInt(argv[5], &serialNum)) {
       fprintf(stdout, "0\n");
       fflush(stdout);
       return 1;
@@ -205,7 +211,7 @@ int main(int argc, const char *argv[]) {
     descriptor.name = @"CloudPlayPlus Virtual Display";
     descriptor.vendorID = 0x4350;
     descriptor.productID = 0x5644;
-    descriptor.serialNum = arc4random();
+    descriptor.serialNum = (unsigned int)serialNum;
     descriptor.maxPixelsWide = (unsigned int)width;
     descriptor.maxPixelsHigh = (unsigned int)height;
     descriptor.sizeInMillimeters = CGSizeMake(597, 336);


### PR DESCRIPTION
## Summary

- Add macOS DMG-only primary-display-only support for managed virtual displays.
- Back up active display modes, origins, and mirror targets before switching topology.
- Restore the saved topology before display teardown or plugin deinit.
- Load SkyLight/SLS symbols dynamically behind `CLOUDPLAYPLUS_DMG_DISTRIBUTION`.

## Validation

- `swiftc -parse -D CLOUDPLAYPLUS_DMG_DISTRIBUTION macos/Classes/HardwareSimulatorPlugin.swift`
- Parent app: `./build.sh --macos --dmg`
- Parent app: `flutter analyze`
- Parent app: `flutter test test/features/remote_desktop/infrastructure/host/rd_host_virtual_display_test.dart`

## Notes

Rotation remains unsupported on macOS by request; this PR only aligns the non-rotation virtual display controls.
