### PR TITLE
fix(macos): create virtual displays with target modes

### DIFF
--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -305,8 +305,10 @@ class HardwareSimulator {
     return HardwareSimulatorPlatform.instance.initParsecVdd();
   }
 
-  static Future<int> createDisplay() {
-    return HardwareSimulatorPlatform.instance.createDisplay();
+  static Future<int> createDisplay({
+    List<Map<String, dynamic>>? configs,
+  }) {
+    return HardwareSimulatorPlatform.instance.createDisplay(configs: configs);
   }
 
   static Future<bool> removeDisplay(int displayUid) {

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -454,8 +454,12 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   }
 
   @override
-  Future<int> createDisplay() async {
-    return await methodChannel.invokeMethod('createDisplay');
+  Future<int> createDisplay({
+    List<Map<String, dynamic>>? configs,
+  }) async {
+    return await methodChannel.invokeMethod('createDisplay', {
+      if (configs != null) 'configs': configs,
+    });
   }
 
   @override

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -257,7 +257,9 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('initParsecVdd() has not been implemented.');
   }
 
-  Future<int> createDisplay() {
+  Future<int> createDisplay({
+    List<Map<String, dynamic>>? configs,
+  }) {
     throw UnimplementedError('createDisplay() has not been implemented.');
   }
 

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -79,7 +79,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     macVirtualDisplayQueue.setSpecific(key: macVirtualDisplayQueueKey, value: ())
   }
 
-  private struct MacVirtualDisplayConfig {
+  private struct MacVirtualDisplayConfig: Hashable {
     let width: Int
     let height: Int
     let refreshRate: Int
@@ -227,6 +227,100 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return MacVirtualDisplayConfig(width: 1920, height: 1080, refreshRate: 60)
   }
 
+  private func macCommonDisplayConfigs(
+    refreshRate: Int = 60
+  ) -> [MacVirtualDisplayConfig] {
+    return [
+      MacVirtualDisplayConfig(width: 1280, height: 720, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 1366, height: 768, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 1600, height: 900, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 1600, height: 1200, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 1920, height: 1080, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 1920, height: 1200, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 2560, height: 1080, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 2560, height: 1440, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 3440, height: 1440, refreshRate: refreshRate),
+      MacVirtualDisplayConfig(width: 3840, height: 2160, refreshRate: refreshRate),
+    ]
+  }
+
+  private func macVirtualDisplayConfig(
+    from raw: [String: Any]
+  ) -> MacVirtualDisplayConfig? {
+    guard
+      let width = raw["width"] as? Int,
+      let height = raw["height"] as? Int,
+      let refreshRate = raw["refreshRate"] as? Int,
+      width > 0,
+      height > 0,
+      refreshRate > 0
+    else {
+      return nil
+    }
+    return MacVirtualDisplayConfig(
+      width: width,
+      height: height,
+      refreshRate: refreshRate
+    )
+  }
+
+  private func macVirtualDisplayConfig(
+    from raw: [String: Int]
+  ) -> MacVirtualDisplayConfig? {
+    guard
+      let width = raw["width"],
+      let height = raw["height"],
+      let refreshRate = raw["refreshRate"],
+      width > 0,
+      height > 0,
+      refreshRate > 0
+    else {
+      return nil
+    }
+    return MacVirtualDisplayConfig(
+      width: width,
+      height: height,
+      refreshRate: refreshRate
+    )
+  }
+
+  private func macCreateDisplayConfigs(
+    primary: MacVirtualDisplayConfig,
+    rawConfigs: [[String: Any]]?
+  ) -> [MacVirtualDisplayConfig] {
+    var configs: [MacVirtualDisplayConfig] = []
+    var seen = Set<MacVirtualDisplayConfig>()
+    func append(_ config: MacVirtualDisplayConfig) {
+      guard !seen.contains(config) else {
+        return
+      }
+      seen.insert(config)
+      configs.append(config)
+    }
+
+    append(primary)
+    if let rawConfigs, !rawConfigs.isEmpty {
+      for raw in rawConfigs {
+        guard let config = macVirtualDisplayConfig(from: raw) else {
+          continue
+        }
+        append(config)
+      }
+      return configs
+    }
+
+    for config in macCommonDisplayConfigs(refreshRate: primary.refreshRate) {
+      append(config)
+    }
+    for raw in macCustomDisplayConfigs().prefix(5) {
+      guard let config = macVirtualDisplayConfig(from: raw) else {
+        continue
+      }
+      append(config)
+    }
+    return configs
+  }
+
   private func readMacHelperDisplayId(from output: Pipe, timeout: DispatchTime) -> String? {
     let handle = output.fileHandleForReading
     let semaphore = DispatchSemaphore(value: 0)
@@ -313,7 +407,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         "refreshRate": refreshRate,
       ]
     }
-    UserDefaults.standard.set(sanitized, forKey: macCustomDisplayConfigsKey)
+    let capped = sanitized.count <= 5
+      ? sanitized
+      : Array(sanitized.suffix(5))
+    UserDefaults.standard.set(capped, forKey: macCustomDisplayConfigsKey)
     return sanitized.count == configs.count
   }
 
@@ -338,7 +435,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private func spawnMacVirtualDisplay(
     width: Int,
     height: Int,
-    refreshRate: Int
+    refreshRate: Int,
+    configs: [MacVirtualDisplayConfig]? = nil
   ) -> Int {
     guard macVirtualDisplayAvailable(), let helper = macHelperURL() else {
       return -1
@@ -347,14 +445,31 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let process = Process()
     let output = Pipe()
     let serial = nextMacVirtualDisplaySerial()
+    let requested = MacVirtualDisplayConfig(
+      width: width,
+      height: height,
+      refreshRate: refreshRate
+    )
+    let displayConfigs = configs ?? macCreateDisplayConfigs(
+      primary: requested,
+      rawConfigs: nil
+    )
     process.executableURL = helper
-    process.arguments = [
+    var arguments = [
       "\(width)",
       "\(height)",
       "\(refreshRate)",
       "\(ProcessInfo.processInfo.processIdentifier)",
       "\(serial)",
     ]
+    arguments.append(contentsOf: displayConfigs.flatMap { config in
+      [
+        "\(config.width)",
+        "\(config.height)",
+        "\(config.refreshRate)",
+      ]
+    })
+    process.arguments = arguments
     process.standardOutput = output
     process.standardError = FileHandle.standardError
 
@@ -557,11 +672,17 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     guard macVirtualDisplayIdsSnapshot().contains(displayId) else {
       return false
     }
+    let config = MacVirtualDisplayConfig(
+      width: width,
+      height: height,
+      refreshRate: refreshRate
+    )
     _ = terminateMacVirtualDisplay(displayId)
     return spawnMacVirtualDisplay(
       width: width,
       height: height,
-      refreshRate: refreshRate
+      refreshRate: refreshRate,
+      configs: macCreateDisplayConfigs(primary: config, rawConfigs: nil)
     ) > 0
   }
 
@@ -2202,12 +2323,22 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     case "initParsecVdd":
       result(macVirtualDisplayAvailable())
     case "createDisplay":
+      let args = call.arguments as? [String: Any]
+      let rawConfigs = args?["configs"] as? [[String: Any]]
       macVirtualDisplayQueue.async {
-        let config = self.macDefaultDisplayConfig()
+        let defaultConfig = self.macDefaultDisplayConfig()
+        let primaryConfig =
+          rawConfigs?.compactMap { self.macVirtualDisplayConfig(from: $0) }.first
+          ?? defaultConfig
+        let configs = self.macCreateDisplayConfigs(
+          primary: primaryConfig,
+          rawConfigs: rawConfigs
+        )
         let id = self.spawnMacVirtualDisplay(
-          width: config.width,
-          height: config.height,
-          refreshRate: config.refreshRate
+          width: primaryConfig.width,
+          height: primaryConfig.height,
+          refreshRate: primaryConfig.refreshRate,
+          configs: configs
         )
         DispatchQueue.main.async { result(id) }
       }

--- a/macos/VirtualDisplayHelper/CloudPlayPlusVirtualDisplayHelper.m
+++ b/macos/VirtualDisplayHelper/CloudPlayPlusVirtualDisplayHelper.m
@@ -96,14 +96,77 @@ static void addMode(NSMutableArray *modes,
   }
 }
 
-static NSArray *buildModes(int width, int height, int refreshRate) {
-  NSMutableArray *modes = [NSMutableArray array];
-  const unsigned int maxWidth = (unsigned int)width;
-  const unsigned int maxHeight = (unsigned int)height;
-  const double hz = (double)refreshRate;
+static void addModeConfig(NSMutableArray *configs,
+                          NSMutableSet *seen,
+                          unsigned int width,
+                          unsigned int height,
+                          int refreshRate,
+                          unsigned int *maxWidth,
+                          unsigned int *maxHeight) {
+  if (width == 0 || height == 0 || refreshRate <= 0) return;
+  NSString *key =
+      [NSString stringWithFormat:@"%ux%u@%d", width, height, refreshRate];
+  if ([seen containsObject:key]) return;
+  [seen addObject:key];
+  [configs addObject:@{
+    @"width" : @(width),
+    @"height" : @(height),
+    @"refreshRate" : @(refreshRate)
+  }];
+  if (maxWidth != NULL && width > *maxWidth) *maxWidth = width;
+  if (maxHeight != NULL && height > *maxHeight) *maxHeight = height;
+}
 
-  addMode(modes, maxWidth, maxHeight, hz, maxWidth, maxHeight);
-  addMode(modes, maxWidth / 2, maxHeight / 2, hz, maxWidth, maxHeight);
+static NSArray *buildModes(int width,
+                           int height,
+                           int refreshRate,
+                           int argc,
+                           const char *argv[],
+                           int startIndex,
+                           unsigned int *outMaxWidth,
+                           unsigned int *outMaxHeight) {
+  NSMutableArray *configs = [NSMutableArray array];
+  NSMutableSet *seen = [NSMutableSet set];
+  unsigned int maxWidth = (unsigned int)width;
+  unsigned int maxHeight = (unsigned int)height;
+  addModeConfig(configs,
+                seen,
+                (unsigned int)width,
+                (unsigned int)height,
+                refreshRate,
+                &maxWidth,
+                &maxHeight);
+
+  for (int i = startIndex; i + 2 < argc; i += 3) {
+    int modeWidth = 0;
+    int modeHeight = 0;
+    int modeRefreshRate = 0;
+    if (!parsePositiveInt(argv[i], &modeWidth) ||
+        !parsePositiveInt(argv[i + 1], &modeHeight) ||
+        !parsePositiveInt(argv[i + 2], &modeRefreshRate)) {
+      continue;
+    }
+    addModeConfig(configs,
+                  seen,
+                  (unsigned int)modeWidth,
+                  (unsigned int)modeHeight,
+                  modeRefreshRate,
+                  &maxWidth,
+                  &maxHeight);
+  }
+
+  NSMutableArray *modes = [NSMutableArray array];
+  for (NSDictionary *config in configs) {
+    addMode(modes,
+            [[config objectForKey:@"width"] unsignedIntValue],
+            [[config objectForKey:@"height"] unsignedIntValue],
+            [[config objectForKey:@"refreshRate"] doubleValue],
+            maxWidth,
+            maxHeight);
+  }
+
+  if (outMaxWidth != NULL) *outMaxWidth = maxWidth;
+  if (outMaxHeight != NULL) *outMaxHeight = maxHeight;
 
   return modes;
 }
@@ -206,14 +269,25 @@ int main(int argc, const char *argv[]) {
     signal(SIGINT, handleSignal);
     signal(SIGHUP, handleSignal);
 
+    unsigned int maxPixelsWide = (unsigned int)width;
+    unsigned int maxPixelsHigh = (unsigned int)height;
+    NSArray *modes = buildModes(width,
+                                height,
+                                refreshRate,
+                                argc,
+                                argv,
+                                6,
+                                &maxPixelsWide,
+                                &maxPixelsHigh);
+
     CGVirtualDisplayDescriptor *descriptor =
         [[CGVirtualDisplayDescriptor alloc] init];
     descriptor.name = @"CloudPlayPlus Virtual Display";
     descriptor.vendorID = 0x4350;
     descriptor.productID = 0x5644;
     descriptor.serialNum = (unsigned int)serialNum;
-    descriptor.maxPixelsWide = (unsigned int)width;
-    descriptor.maxPixelsHigh = (unsigned int)height;
+    descriptor.maxPixelsWide = maxPixelsWide;
+    descriptor.maxPixelsHigh = maxPixelsHigh;
     descriptor.sizeInMillimeters = CGSizeMake(597, 336);
     descriptor.whitePoint = CGPointMake(0.3127, 0.3290);
     descriptor.redPrimary = CGPointMake(0.64, 0.33);
@@ -231,7 +305,7 @@ int main(int argc, const char *argv[]) {
     CGVirtualDisplaySettings *settings =
         [[CGVirtualDisplaySettings alloc] init];
     settings.hiDPI = 1;
-    settings.modes = buildModes(width, height, refreshRate);
+    settings.modes = modes;
 
     fprintf(stderr,
             "[cloudplayplus_vd_helper] creating %dx%d@%d\n",


### PR DESCRIPTION
## Summary
- allow `createDisplay` to receive virtual display mode configs from Dart
- start the macOS virtual display helper with the requested target mode plus additional supported modes
- include common modes and cap stored custom modes to 5 entries

## Validation
- `dart format --set-exit-if-changed lib/ test/ plugins/hardware_simulator/lib/`
- `flutter analyze`
- `flutter test`
- `./build.sh --macos --dmg` from the main app repo
