### PR TITLE
fix(windows): route touch and pen through service

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -45,7 +45,8 @@ add_library(${PLUGIN_NAME} SHARED
 )
 
 # Add specific compiler options to ignore warnings from parsec-vdd.h
-target_compile_options(${PLUGIN_NAME} PRIVATE /wd"4245" /wd"4505")
+target_compile_options(${PLUGIN_NAME} PRIVATE
+  /wd"4245" /wd"4505" /wd"4828" /utf-8)
 
 # Apply a standard set of build settings that are configured in the
 # application-level CMakeLists.txt. This can be removed for plugins that want

--- a/windows/desktop_service_input_client.cpp
+++ b/windows/desktop_service_input_client.cpp
@@ -11,11 +11,14 @@ constexpr uint32_t kMsgKeyInput = 0x02;
 constexpr uint32_t kMsgMouseInput = 0x03;
 constexpr uint32_t kMsgGetCustomDisplayConfigs = 0x04;
 constexpr uint32_t kMsgSetCustomDisplayConfigs = 0x05;
+constexpr uint32_t kMsgTouchInput = 0x06;
+constexpr uint32_t kMsgPenInput = 0x07;
 constexpr uint32_t kMsgCustomDisplayConfigsResp = 0x84;
 constexpr uint32_t kMsgBoolResp = 0x85;
 constexpr uint32_t kMsgErrorResp = 0xFF;
 constexpr uint32_t kMaxMessageSize = 4096;
 constexpr uint32_t kMaxCustomDisplayConfigs = 5;
+constexpr uint32_t kMaxTouchContacts = 10;
 constexpr DWORD kConnectBusyWaitMs = 2;
 constexpr DWORD kWriteTimeoutMs = 20;
 constexpr DWORD kControlTimeoutMs = 1000;
@@ -40,6 +43,39 @@ struct MouseInputPayload {
   int32_t data;
 };
 
+struct TouchContactPayload {
+  uint32_t pointer_id;
+  uint32_t pointer_flags;
+  int32_t x;
+  int32_t y;
+  uint32_t touch_flags;
+  uint32_t touch_mask;
+  int32_t contact_left;
+  int32_t contact_top;
+  int32_t contact_right;
+  int32_t contact_bottom;
+  uint32_t orientation;
+  uint32_t pressure;
+};
+
+struct TouchInputPayload {
+  uint32_t count;
+  TouchContactPayload contacts[kMaxTouchContacts];
+};
+
+struct PenInputPayload {
+  uint32_t pointer_id;
+  uint32_t pointer_flags;
+  int32_t x;
+  int32_t y;
+  uint32_t pen_flags;
+  uint32_t pen_mask;
+  uint32_t pressure;
+  int32_t rotation;
+  int32_t tilt_x;
+  int32_t tilt_y;
+};
+
 struct CustomDisplayConfigPayload {
   uint32_t width;
   uint32_t height;
@@ -61,6 +97,12 @@ static_assert(sizeof(KeyboardInputPayload) == 8,
               "KeyboardInput size must match service IPC");
 static_assert(sizeof(MouseInputPayload) == 16,
               "MouseInput size must match service IPC");
+static_assert(sizeof(TouchContactPayload) == 48,
+              "TouchContact size must match service IPC");
+static_assert(sizeof(TouchInputPayload) == 484,
+              "TouchInput size must match service IPC");
+static_assert(sizeof(PenInputPayload) == 40,
+              "PenInput size must match service IPC");
 static_assert(sizeof(CustomDisplayConfigPayload) == 12,
               "CustomDisplayConfig size must match service IPC");
 static_assert(sizeof(CustomDisplayConfigListPayload) == 64,
@@ -108,6 +150,82 @@ bool DesktopServiceInputClient::SendInputMessage(const INPUT& input) {
     default:
       return false;
   }
+}
+
+bool DesktopServiceInputClient::SendTouchInput(
+    const POINTER_TYPE_INFO* pointers,
+    uint32_t count) {
+  if (!pointers || count == 0 || count > kMaxTouchContacts) {
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (pipe_ == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  TouchInputPayload payload = {};
+  payload.count = count;
+  for (uint32_t i = 0; i < count; ++i) {
+    if (pointers[i].type != PT_TOUCH) {
+      return false;
+    }
+    const auto& source = pointers[i].touchInfo;
+    auto& target = payload.contacts[i];
+    target.pointer_id = source.pointerInfo.pointerId;
+    target.pointer_flags = source.pointerInfo.pointerFlags;
+    target.x = source.pointerInfo.ptPixelLocation.x;
+    target.y = source.pointerInfo.ptPixelLocation.y;
+    target.touch_flags = source.touchFlags;
+    target.touch_mask = source.touchMask;
+    target.contact_left = source.rcContact.left;
+    target.contact_top = source.rcContact.top;
+    target.contact_right = source.rcContact.right;
+    target.contact_bottom = source.rcContact.bottom;
+    target.orientation = source.orientation;
+    target.pressure = source.pressure;
+  }
+
+  uint8_t buffer[sizeof(MsgHeader) + sizeof(TouchInputPayload)] = {};
+  MsgHeader header = {};
+  header.type = kMsgTouchInput;
+  header.payload_size = sizeof(TouchInputPayload);
+  memcpy(buffer, &header, sizeof(header));
+  memcpy(buffer + sizeof(header), &payload, sizeof(payload));
+  return SendRawLocked(buffer, sizeof(buffer));
+}
+
+bool DesktopServiceInputClient::SendPenInput(
+    const POINTER_TYPE_INFO& pointer) {
+  if (pointer.type != PT_PEN) {
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (pipe_ == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  const auto& source = pointer.penInfo;
+  PenInputPayload payload = {};
+  payload.pointer_id = source.pointerInfo.pointerId;
+  payload.pointer_flags = source.pointerInfo.pointerFlags;
+  payload.x = source.pointerInfo.ptPixelLocation.x;
+  payload.y = source.pointerInfo.ptPixelLocation.y;
+  payload.pen_flags = source.penFlags;
+  payload.pen_mask = source.penMask;
+  payload.pressure = source.pressure;
+  payload.rotation = source.rotation;
+  payload.tilt_x = source.tiltX;
+  payload.tilt_y = source.tiltY;
+
+  uint8_t buffer[sizeof(MsgHeader) + sizeof(PenInputPayload)] = {};
+  MsgHeader header = {};
+  header.type = kMsgPenInput;
+  header.payload_size = sizeof(PenInputPayload);
+  memcpy(buffer, &header, sizeof(header));
+  memcpy(buffer + sizeof(header), &payload, sizeof(payload));
+  return SendRawLocked(buffer, sizeof(buffer));
 }
 
 bool DesktopServiceInputClient::GetCustomDisplayConfigs(

--- a/windows/desktop_service_input_client.h
+++ b/windows/desktop_service_input_client.h
@@ -19,6 +19,8 @@ class DesktopServiceInputClient {
 
   void SetServiceAvailable(bool available);
   bool SendInputMessage(const INPUT& input);
+  bool SendTouchInput(const POINTER_TYPE_INFO* pointers, uint32_t count);
+  bool SendPenInput(const POINTER_TYPE_INFO& pointer);
   bool GetCustomDisplayConfigs(
       std::vector<VirtualDisplay::DisplayConfig>& configs);
   bool SetCustomDisplayConfigs(

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -96,8 +96,7 @@ static void clearPenEdgeTriggeredFlags() {
 }
 
 static bool hasActivePenPointer() {
-    return g_penDevice &&
-        g_penInfo.penInfo.pointerInfo.pointerFlags != POINTER_FLAG_NONE;
+    return g_penInfo.penInfo.pointerInfo.pointerFlags != POINTER_FLAG_NONE;
 }
 
 static bool hasHoverOnlyPenPointer() {
@@ -398,7 +397,15 @@ void destroyPenDevice() {
 }
 
 bool sendTouchInput() {
-    if (!g_touchDevice || !fnInjectSyntheticPointerInput) {
+    if (DesktopServiceInputClient::Instance().SendTouchInput(
+            g_touchInfo, g_activeTouchSlots)) {
+        return true;
+    }
+
+    if (!g_touchDevice && !createTouchDevice()) {
+        return false;
+    }
+    if (!fnInjectSyntheticPointerInput) {
         return false;
     }
 
@@ -436,7 +443,14 @@ void send_touch_input() {
 }
 
 bool sendPenInput() {
-    if (!g_penDevice || !fnInjectSyntheticPointerInput) {
+    if (DesktopServiceInputClient::Instance().SendPenInput(g_penInfo)) {
+        return true;
+    }
+
+    if (!g_penDevice && !createPenDevice()) {
+        return false;
+    }
+    if (!fnInjectSyntheticPointerInput) {
         return false;
     }
 
@@ -474,12 +488,6 @@ void send_pen_input() {
 }
 
 void performTouchEvent(int screenId, double x, double y, uint32_t touchId, bool isDown, bool isRepeat = false) {
-    if (!g_touchDevice) {
-        if (!createTouchDevice()) {
-            return;
-        }
-    }
-
     POINTER_TYPE_INFO* pointer = nullptr;
     for (UINT32 i = 0; i < ARRAYSIZE(g_touchInfo); i++) {
         if (g_touchInfo[i].touchInfo.pointerInfo.pointerId == touchId) {
@@ -541,10 +549,6 @@ void performTouchEvent(int screenId, double x, double y, uint32_t touchId, bool 
 }
 
 void performTouchMove(int screenId, double x, double y, uint32_t touchId) {
-    if (!g_touchDevice) {
-        return;
-    }
-
     POINTER_TYPE_INFO* pointer = nullptr;
     for (UINT32 i = 0; i < ARRAYSIZE(g_touchInfo); i++) {
         if (g_touchInfo[i].touchInfo.pointerInfo.pointerId == touchId) {
@@ -584,12 +588,6 @@ void performTouchMove(int screenId, double x, double y, uint32_t touchId) {
 
 void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButton, double pressure, double rotation, double tilt) {
     std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
-
-    if (!g_penDevice) {
-        if (!createPenDevice()) {
-            return;
-        }
-    }
 
     g_penInfo.type = PT_PEN;
     auto& penInfo = g_penInfo.penInfo;
@@ -667,7 +665,7 @@ void performPenEvent(int screenId, double x, double y, bool isDown, bool hasButt
 void performPenMove(int screenId, double x, double y, bool hasButton, double pressure, double rotation, double tilt) {
     std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
 
-    if (!g_penDevice) {
+    if (g_penInfo.penInfo.pointerInfo.pointerFlags == POINTER_FLAG_NONE) {
         return;
     }
 
@@ -737,12 +735,6 @@ void performPenMove(int screenId, double x, double y, bool hasButton, double pre
 
 void performPenHover(int screenId, double x, double y) {
     std::unique_lock<std::recursive_mutex> lock(g_event_mutex);
-
-    if (!g_penDevice) {
-        if (!createPenDevice()) {
-            return;
-        }
-    }
 
     g_penInfo.type = PT_PEN;
     auto& penInfo = g_penInfo.penInfo;


### PR DESCRIPTION
## What changed

- serialize the existing full multi-touch and pen pointer snapshots over the service input pipe
- keep the current 300 ms touch repeat, 50 ms pen refresh, 250 ms hover expiry, edge-flag cleanup, coordinate conversion, and pressure/rotation/tilt logic in the plugin
- keep local synthetic-pointer injection as the fallback when the service pipe is unavailable
- avoid per-event threads on the service path; the existing persistent pipe connection and service dispatcher are reused
- compile plugin sources as UTF-8 while suppressing invalid-byte warnings from the vendored ViGEm header

## Why

Mouse and keyboard already use the SYSTEM service, but touch and pen were still injected from the user process and failed across UIPI/UAC boundaries.

## Validation

- `dart format lib/ test/` (0 changed)
- `flutter analyze`
- `flutter test`: 665 passed, 1 skipped
- `flutter build windows --release`
- release artifact: `build/windows/x64/runner/Release/cloudplayplus.exe`

## Dependency

Pair with the CloudPlayPlusService PR for `MSG_TOUCH_INPUT` / `MSG_PEN_INPUT`, then bump both submodule pointers in the client repository.
