### PR TITLE
feat(logging): integrate shared native logger

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -24,6 +24,7 @@ list(APPEND PLUGIN_SOURCES
   "hardware_simulator_plugin.h"
   "cursor_monitor.cc"
   "cursor_monitor.h"
+  "cpp_log_shim.h"
   "gamecontroller_manager.cc"
   "gamecontroller_manager.h"
   "notification_window.cc"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -59,6 +59,13 @@ apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+if(TARGET cpp_log_plugin)
+  target_compile_definitions(${PLUGIN_NAME} PRIVATE CPP_LOG_AVAILABLE=1)
+  target_link_libraries(${PLUGIN_NAME} PRIVATE cpp_log_plugin)
+else()
+  message(STATUS
+    "hardware_simulator: cpp_log target unavailable; native logging disabled")
+endif()
 
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.

--- a/windows/cpp_log_shim.h
+++ b/windows/cpp_log_shim.h
@@ -1,0 +1,47 @@
+#ifndef HARDWARE_SIMULATOR_WINDOWS_CPP_LOG_SHIM_H_
+#define HARDWARE_SIMULATOR_WINDOWS_CPP_LOG_SHIM_H_
+
+#if defined(CPP_LOG_AVAILABLE)
+#include <cpp_log/cpp_log.h>
+#else
+#include <cstdarg>
+#include <cstdio>
+
+namespace hardware_simulator {
+namespace logging {
+
+inline void FallbackLog(const char* level, const char* tag,
+                        const char* format, ...) {
+  char message[2048] = {};
+  va_list args;
+  va_start(args, format);
+  std::vsnprintf(message, sizeof(message), format, args);
+  va_end(args);
+  std::fprintf(stderr, "[%s] [%s] %s\n", level,
+               tag && *tag ? tag : "NATIVE", message);
+}
+
+}  // namespace logging
+}  // namespace hardware_simulator
+
+#define CPPLOG_TRACE(tag, ...)                                      \
+  ::hardware_simulator::logging::FallbackLog("TRACE", (tag),        \
+                                              __VA_ARGS__)
+#define CPPLOG_DEBUG(tag, ...)                                      \
+  ::hardware_simulator::logging::FallbackLog("DEBUG", (tag),        \
+                                              __VA_ARGS__)
+#define CPPLOG_INFO(tag, ...)                                      \
+  ::hardware_simulator::logging::FallbackLog("INFO", (tag),        \
+                                              __VA_ARGS__)
+#define CPPLOG_WARN(tag, ...)                                      \
+  ::hardware_simulator::logging::FallbackLog("WARN", (tag),        \
+                                              __VA_ARGS__)
+#define CPPLOG_ERROR(tag, ...)                                     \
+  ::hardware_simulator::logging::FallbackLog("ERROR", (tag),       \
+                                              __VA_ARGS__)
+#define CPPLOG_CRITICAL(tag, ...)                                  \
+  ::hardware_simulator::logging::FallbackLog("CRITICAL", (tag),    \
+                                              __VA_ARGS__)
+#endif
+
+#endif  // HARDWARE_SIMULATOR_WINDOWS_CPP_LOG_SHIM_H_

--- a/windows/gamecontroller_manager.cc
+++ b/windows/gamecontroller_manager.cc
@@ -1,5 +1,27 @@
 #include "gamecontroller_manager.h"
 
+#if defined(CPP_LOG_AVAILABLE)
+#include <cpp_log/cpp_log.h>
+#else
+#include <cstdarg>
+#include <cstdio>
+
+namespace {
+void FallbackLog(const char* level, const char* tag, const char* format, ...) {
+  std::fprintf(stderr, "[%s] [%s] ", level, tag);
+  va_list args;
+  va_start(args, format);
+  std::vfprintf(stderr, format, args);
+  va_end(args);
+  std::fputc('\n', stderr);
+}
+}  // namespace
+
+#define CPPLOG_INFO(tag, ...) FallbackLog("INFO", (tag), __VA_ARGS__)
+#define CPPLOG_WARN(tag, ...) FallbackLog("WARN", (tag), __VA_ARGS__)
+#define CPPLOG_ERROR(tag, ...) FallbackLog("ERROR", (tag), __VA_ARGS__)
+#endif
+
 #include <sstream>
 #include <Xinput.h>
 
@@ -10,14 +32,14 @@ std::array<PVIGEM_TARGET, 4> GameControllerManager::controllers = {};
 int GameControllerManager::InitializeVigem() {
   vigem_client = vigem_alloc();
   if (vigem_client == nullptr) {
-    std::cerr << "Uh, not enough memory to do that?!" << std::endl;
+    CPPLOG_ERROR("GAMEPAD", "ViGEm client allocation failed");
     return -1;
   }
 
   const auto retval = vigem_connect(vigem_client);
   if (!VIGEM_SUCCESS(retval)) {
-    std::cerr << "ViGEm Bus connection failed with error code: 0x"
-              << std::hex << retval << std::endl;
+    CPPLOG_ERROR("GAMEPAD", "ViGEm Bus connection failed: 0x%X",
+                 static_cast<unsigned int>(retval));
     return -1;
   }
   initialized = true;
@@ -43,22 +65,22 @@ int GameControllerManager::CreateGameController() {
       // Error handling
       //
       if (!VIGEM_SUCCESS(pir)) {
-        std::cerr << "Target plugin failed with error code: 0x" << std::hex
-                << pir << std::endl;
+        CPPLOG_ERROR("GAMEPAD", "ViGEm target add failed: 0x%X",
+                     static_cast<unsigned int>(pir));
         return -1;
       }
-      std::cout << "GameController created in slot " << i + 1 << std::endl;
+      CPPLOG_INFO("GAMEPAD", "Game controller created in slot %d", i + 1);
       return i + 1;
     }
   }
 
-  std::cerr << "No available slot for GameController!" << std::endl;
+  CPPLOG_WARN("GAMEPAD", "No available game controller slot");
   return -1;
 }
 
 bool GameControllerManager::RemoveGameController(int id) {
   if (id < 1 || id > 4) {
-    std::cerr << "Invalid slot id: " << id << std::endl;
+    CPPLOG_WARN("GAMEPAD", "Invalid game controller slot: %d", id);
     return false;
   }
 
@@ -69,15 +91,15 @@ bool GameControllerManager::RemoveGameController(int id) {
     // Error handling
     //
     if (!VIGEM_SUCCESS(pir)) {
-        std::cerr << "GameController remove failed with error code: 0x" << std::hex
-            << pir << std::endl;
+        CPPLOG_ERROR("GAMEPAD", "Game controller removal failed: 0x%X",
+                     static_cast<unsigned int>(pir));
         return false;
     }
-    std::cout << "GameController removed from slot " << id << std::endl;
+    CPPLOG_INFO("GAMEPAD", "Game controller removed from slot %d", id);
     return true;
   }
 
-  std::cerr << "Slot " << id << " is already empty!" << std::endl;
+  CPPLOG_WARN("GAMEPAD", "Game controller slot %d is already empty", id);
   return false;
 }
 
@@ -103,10 +125,9 @@ bool GameControllerManager::DoControllerAction(int id, std::string& action) {
         *reinterpret_cast<XUSB_REPORT*>(&gamepad));
 
     if (!VIGEM_SUCCESS(pir)) {
-        std::cerr << "GameController remove failed with error code: 0x" << std::hex
-            << pir << std::endl;
+        CPPLOG_ERROR("GAMEPAD", "Game controller update failed: 0x%X",
+                     static_cast<unsigned int>(pir));
         return false;
     }
-    std::cout << "GameController removed from slot " << id << std::endl;
     return true;
 }

--- a/windows/gamecontroller_manager.cc
+++ b/windows/gamecontroller_manager.cc
@@ -1,26 +1,5 @@
 #include "gamecontroller_manager.h"
-
-#if defined(CPP_LOG_AVAILABLE)
-#include <cpp_log/cpp_log.h>
-#else
-#include <cstdarg>
-#include <cstdio>
-
-namespace {
-void FallbackLog(const char* level, const char* tag, const char* format, ...) {
-  std::fprintf(stderr, "[%s] [%s] ", level, tag);
-  va_list args;
-  va_start(args, format);
-  std::vfprintf(stderr, format, args);
-  va_end(args);
-  std::fputc('\n', stderr);
-}
-}  // namespace
-
-#define CPPLOG_INFO(tag, ...) FallbackLog("INFO", (tag), __VA_ARGS__)
-#define CPPLOG_WARN(tag, ...) FallbackLog("WARN", (tag), __VA_ARGS__)
-#define CPPLOG_ERROR(tag, ...) FallbackLog("ERROR", (tag), __VA_ARGS__)
-#endif
+#include "cpp_log_shim.h"
 
 #include <sstream>
 #include <Xinput.h>

--- a/windows/gamecontroller_manager.h
+++ b/windows/gamecontroller_manager.h
@@ -1,9 +1,9 @@
 #ifndef GAME_CONTROLLER_MANAGER_H
 #define GAME_CONTROLLER_MANAGER_H
 
-#include <iostream>
-#include <memory>
 #include <array>
+#include <memory>
+#include <string>
 
 #include <ViGEm/Client.h>
 
@@ -11,7 +11,7 @@ class GameControllerManager {
 public:
   static int CreateGameController();
   static bool RemoveGameController(int id);
-  static bool DoControllerAction(int id,std::string& action);
+  static bool DoControllerAction(int id, std::string& action);
 
 private:
   static int InitializeVigem();


### PR DESCRIPTION
## What changed

- link the Windows plugin to the host-provided `cpp_log_plugin` target when available
- route representative ViGEm game-controller diagnostics through the shared native logger
- preserve standalone builds with a stderr fallback when the host does not provide `cpp_log`
- avoid a mandatory Dart path dependency on a sibling package

## Why

Native plugin diagnostics should share CloudPlayPlus's bounded asynchronous logger and rotating file sink instead of maintaining separate output paths, while this plugin must remain independently buildable.

## Validation

- `flutter pub get`
- standalone `example`: `flutter build windows --debug`
- CloudPlayPlus host Windows Release build with the shared `cpp_log.dll`
- `flutter analyze` still reports the repository's existing 268 example lint items; this PR does not change Dart sources