### PR TITLE
fix: align native scroll direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Define a cross-platform logical scroll contract and convert it at each
+  native host boundary.
+* Reduce the empirical Windows scroll sensitivity from 2.0 to 1.5.
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -62,6 +62,10 @@ class HWMouse {
     HardwareSimulatorPlatform.instance.performMouseClick(buttonId, isDown);
   }
 
+  /// Injects a canonical logical scroll delta.
+  ///
+  /// Positive x scrolls right and positive y scrolls down. Platform
+  /// implementations convert these values to their native wheel conventions.
   void performMouseScroll(double dx, double dy) {
     HardwareSimulatorPlatform.instance.performMouseScroll(dx, dy);
   }

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -215,6 +215,7 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('performMouseClick() has not been implemented.');
   }
 
+  /// Injects logical scroll: positive x is right, positive y is down.
   Future<void> performMouseScroll(double dx, double dy) async {
     throw UnimplementedError('performMouseScroll() has not been implemented.');
   }

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -479,7 +479,7 @@ FlMethodResponse* perform_mouse_scroll(FlValue* args) {
     return linux_mouse_error();
   }
 
-  int vertical_distance = static_cast<int>(std::round(dy));
+  int vertical_distance = logical_vertical_scroll_to_linux_wheel(dy);
   int horizontal_distance = static_cast<int>(std::round(dx));
   if (vertical_distance != 0) {
     std::lock_guard<std::mutex> lock(g_input_mutex);
@@ -555,6 +555,10 @@ FlMethodResponse* clear_all_pressed_events() {
 }
 
 }  // namespace
+
+int logical_vertical_scroll_to_linux_wheel(double dy) {
+  return static_cast<int>(std::round(-dy));
+}
 
 // Called when a method call is received from Flutter.
 static void hardware_simulator_plugin_handle_method_call(

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -56,6 +56,7 @@ int g_last_abs_x = 0;
 int g_last_abs_y = 0;
 int g_last_abs_width = 1;
 int g_last_abs_height = 1;
+constexpr double kMaxLinuxWheelDistance = 12000.0;
 
 FlMethodResponse* success_null() {
   return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
@@ -557,7 +558,12 @@ FlMethodResponse* clear_all_pressed_events() {
 }  // namespace
 
 int logical_vertical_scroll_to_linux_wheel(double dy) {
-  return static_cast<int>(std::round(-dy));
+  if (!std::isfinite(dy)) {
+    return 0;
+  }
+  const double native_distance = (std::clamp)(
+      -dy, -kMaxLinuxWheelDistance, kMaxLinuxWheelDistance);
+  return static_cast<int>(std::lround(native_distance));
 }
 
 // Called when a method call is received from Flutter.

--- a/linux/hardware_simulator_plugin.cc
+++ b/linux/hardware_simulator_plugin.cc
@@ -56,6 +56,7 @@ int g_last_abs_x = 0;
 int g_last_abs_y = 0;
 int g_last_abs_width = 1;
 int g_last_abs_height = 1;
+// About 100 conventional wheel notches at 120 units per notch.
 constexpr double kMaxLinuxWheelDistance = 12000.0;
 
 FlMethodResponse* success_null() {
@@ -480,8 +481,8 @@ FlMethodResponse* perform_mouse_scroll(FlValue* args) {
     return linux_mouse_error();
   }
 
-  int vertical_distance = logical_vertical_scroll_to_linux_wheel(dy);
-  int horizontal_distance = static_cast<int>(std::round(dx));
+  int vertical_distance = logical_scroll_to_linux_wheel(dy, true);
+  int horizontal_distance = logical_scroll_to_linux_wheel(dx, false);
   if (vertical_distance != 0) {
     std::lock_guard<std::mutex> lock(g_input_mutex);
     mouse->vertical_scroll(vertical_distance);
@@ -557,12 +558,13 @@ FlMethodResponse* clear_all_pressed_events() {
 
 }  // namespace
 
-int logical_vertical_scroll_to_linux_wheel(double dy) {
-  if (!std::isfinite(dy)) {
+int logical_scroll_to_linux_wheel(double delta, bool invert) {
+  if (!std::isfinite(delta)) {
     return 0;
   }
+  const double direction = invert ? -1.0 : 1.0;
   const double native_distance = (std::clamp)(
-      -dy, -kMaxLinuxWheelDistance, kMaxLinuxWheelDistance);
+      delta * direction, -kMaxLinuxWheelDistance, kMaxLinuxWheelDistance);
   return static_cast<int>(std::lround(native_distance));
 }
 

--- a/linux/hardware_simulator_plugin_private.h
+++ b/linux/hardware_simulator_plugin_private.h
@@ -8,3 +8,7 @@
 
 // Handles the getPlatformVersion method call.
 FlMethodResponse *get_platform_version();
+
+// Converts canonical logical vertical scroll (+ is page-down) to Linux
+// REL_WHEEL direction (+ is wheel-up/page-up).
+int logical_vertical_scroll_to_linux_wheel(double dy);

--- a/linux/hardware_simulator_plugin_private.h
+++ b/linux/hardware_simulator_plugin_private.h
@@ -9,6 +9,7 @@
 // Handles the getPlatformVersion method call.
 FlMethodResponse *get_platform_version();
 
-// Converts canonical logical vertical scroll (+ is page-down) to Linux
-// REL_WHEEL direction (+ is wheel-up/page-up).
-int logical_vertical_scroll_to_linux_wheel(double dy);
+// Converts a canonical logical scroll delta to Linux wheel units. Set invert
+// for the vertical REL_WHEEL axis (+ is wheel-up/page-up); horizontal
+// REL_HWHEEL already matches the logical +right direction.
+int logical_scroll_to_linux_wheel(double delta, bool invert);

--- a/linux/test/hardware_simulator_plugin_test.cc
+++ b/linux/test/hardware_simulator_plugin_test.cc
@@ -2,6 +2,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "include/hardware_simulator/hardware_simulator_plugin.h"
 #include "hardware_simulator_plugin_private.h"
 
@@ -31,6 +33,11 @@ TEST(HardwareSimulatorPlugin, ConvertsLogicalVerticalScrollToLinuxWheel) {
   EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(-80.0), 80);
   EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(80.0), -80);
   EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(0.0), 0);
+  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(-1e100), 12000);
+  EXPECT_EQ(
+      logical_vertical_scroll_to_linux_wheel(
+          std::numeric_limits<double>::infinity()),
+      0);
 }
 
 }  // namespace test

--- a/linux/test/hardware_simulator_plugin_test.cc
+++ b/linux/test/hardware_simulator_plugin_test.cc
@@ -29,14 +29,16 @@ TEST(HardwareSimulatorPlugin, GetPlatformVersion) {
   EXPECT_THAT(fl_value_get_string(result), testing::StartsWith("Linux "));
 }
 
-TEST(HardwareSimulatorPlugin, ConvertsLogicalVerticalScrollToLinuxWheel) {
-  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(-80.0), 80);
-  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(80.0), -80);
-  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(0.0), 0);
-  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(-1e100), 12000);
+TEST(HardwareSimulatorPlugin, ConvertsLogicalScrollToLinuxWheel) {
+  EXPECT_EQ(logical_scroll_to_linux_wheel(-80.0, true), 80);
+  EXPECT_EQ(logical_scroll_to_linux_wheel(80.0, true), -80);
+  EXPECT_EQ(logical_scroll_to_linux_wheel(0.0, true), 0);
+  EXPECT_EQ(logical_scroll_to_linux_wheel(-1e100, true), 12000);
+  EXPECT_EQ(logical_scroll_to_linux_wheel(80.0, false), 80);
+  EXPECT_EQ(logical_scroll_to_linux_wheel(-1e100, false), -12000);
   EXPECT_EQ(
-      logical_vertical_scroll_to_linux_wheel(
-          std::numeric_limits<double>::infinity()),
+      logical_scroll_to_linux_wheel(
+          std::numeric_limits<double>::infinity(), false),
       0);
 }
 

--- a/linux/test/hardware_simulator_plugin_test.cc
+++ b/linux/test/hardware_simulator_plugin_test.cc
@@ -27,5 +27,11 @@ TEST(HardwareSimulatorPlugin, GetPlatformVersion) {
   EXPECT_THAT(fl_value_get_string(result), testing::StartsWith("Linux "));
 }
 
+TEST(HardwareSimulatorPlugin, ConvertsLogicalVerticalScrollToLinuxWheel) {
+  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(-80.0), 80);
+  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(80.0), -80);
+  EXPECT_EQ(logical_vertical_scroll_to_linux_wheel(0.0), 0);
+}
+
 }  // namespace test
 }  // namespace hardware_simulator

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1843,7 +1843,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
       if dx != 0 || dy != 0 {
           let wheelCount: UInt32 = dx != 0 ? 2 : 1
-          if let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: wheelCount, wheel1: Int32(dy), wheel2: Int32(dx), wheel3: 0) {
+          // RD_MOUSE_SCROLL uses logical page direction (+x right, +y down).
+          // CoreGraphics wheel deltas use the opposite physical direction.
+          let verticalWheel = Int32((-dy).rounded())
+          let horizontalWheel = Int32((-dx).rounded())
+          if let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: wheelCount, wheel1: verticalWheel, wheel2: horizontalWheel, wheel3: 0) {
               scrollEvent.post(tap: .cghidEventTap)
           }
       }

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1838,15 +1838,30 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
   }
 
+  private func nativeWheelDelta(_ logicalDelta: Double) -> Int32? {
+      guard logicalDelta.isFinite else { return nil }
+      let rounded = (-logicalDelta).rounded()
+      let clamped = min(
+          max(rounded, Double(Int32.min)),
+          Double(Int32.max)
+      )
+      return Int32(clamped)
+  }
+
   func performMouseScroll(dx: Double, dy: Double) {
       let eventSource = CGEventSource(stateID: .hidSystemState)
 
-      if dx != 0 || dy != 0 {
-          let wheelCount: UInt32 = dx != 0 ? 2 : 1
+      guard
+          let verticalWheel = nativeWheelDelta(dy),
+          let horizontalWheel = nativeWheelDelta(dx)
+      else {
+          return
+      }
+
+      if horizontalWheel != 0 || verticalWheel != 0 {
+          let wheelCount: UInt32 = horizontalWheel != 0 ? 2 : 1
           // RD_MOUSE_SCROLL uses logical page direction (+x right, +y down).
-          // CoreGraphics wheel deltas use the opposite physical direction.
-          let verticalWheel = Int32((-dy).rounded())
-          let horizontalWheel = Int32((-dx).rounded())
+          // CoreGraphics wheel1/wheel2 use physical direction (+up/+left).
           if let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: wheelCount, wheel1: verticalWheel, wheel2: horizontalWheel, wheel3: 0) {
               scrollEvent.post(tap: .cghidEventTap)
           }

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -51,7 +51,8 @@ constexpr ULONG_PTR kCursorReseedExtraInfo =
     static_cast<ULONG_PTR>(0x43505052);  // "CPPR"
 constexpr UINT_PTR kCursorReseedSubclassId =
     static_cast<UINT_PTR>(0x43505052);
-// Empirical Windows scroll-speed tuning requested by the product.
+// Empirical tuning: maps Flutter page-scroll deltas to the desired Win32
+// wheel speed while preserving the logical protocol value on the wire.
 constexpr double kWindowsWheelSensitivity = 1.5;
 constexpr double kMaxWindowsWheelDistance =
     static_cast<double>(WHEEL_DELTA) * 100.0;

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -51,6 +51,7 @@ constexpr ULONG_PTR kCursorReseedExtraInfo =
     static_cast<ULONG_PTR>(0x43505052);  // "CPPR"
 constexpr UINT_PTR kCursorReseedSubclassId =
     static_cast<UINT_PTR>(0x43505052);
+constexpr double kWindowsWheelUnitsPerLogicalScrollUnit = 1.5;
 
 LRESULT CALLBACK CursorReseedSubclassProc(
     HWND window,
@@ -1365,6 +1366,23 @@ void hscroll(int distance) {
     send_input(i);
 }
 
+void performMouseScroll(double dx, double dy) {
+    // RD_MOUSE_SCROLL uses logical page direction: +x right, +y down.
+    // Win32 horizontal wheel uses the same sign, while vertical wheel uses
+    // the physical wheel direction (+ is forward/page-up), so y is inverted.
+    const int horizontal_distance = static_cast<int>(
+        std::lround(dx * kWindowsWheelUnitsPerLogicalScrollUnit));
+    const int vertical_distance = static_cast<int>(
+        std::lround(-dy * kWindowsWheelUnitsPerLogicalScrollUnit));
+
+    if (horizontal_distance != 0) {
+        hscroll(horizontal_distance);
+    }
+    if (vertical_distance != 0) {
+        scroll(vertical_distance);
+    }
+}
+
 std::wstring stringToWstring(const std::string& str) {
     int wideCharLen = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
     if (wideCharLen <= 0) return L"";
@@ -1433,14 +1451,9 @@ void HardwareSimulatorPlugin::HandleMethodCall(
   } else if (method_call.method_name().compare("mouseScroll") == 0) {
         auto dx = (args->find(flutter::EncodableValue("dx")))->second;
         auto dy = (args->find(flutter::EncodableValue("dy")))->second;
-        int deltax = static_cast<double>(std::get<double>((dx)));
-        int deltay = static_cast<double>(std::get<double>((dy)));
-        if (deltax!=0){
-          hscroll(deltax * 2);
-        }
-        if (deltay!=0){
-          scroll(deltay * 2);
-        }
+        performMouseScroll(
+            std::get<double>(dx),
+            std::get<double>(dy));
         result->Success(nullptr);
   } else if (method_call.method_name().compare("hookCursorImage") == 0) {
         auto callbackID = static_cast<int>(std::get<int>((args->find(flutter::EncodableValue("callbackID")))->second));

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -51,7 +51,22 @@ constexpr ULONG_PTR kCursorReseedExtraInfo =
     static_cast<ULONG_PTR>(0x43505052);  // "CPPR"
 constexpr UINT_PTR kCursorReseedSubclassId =
     static_cast<UINT_PTR>(0x43505052);
-constexpr double kWindowsWheelUnitsPerLogicalScrollUnit = 1.5;
+// Empirical Windows scroll-speed tuning requested by the product.
+constexpr double kWindowsWheelSensitivity = 1.5;
+constexpr double kMaxWindowsWheelDistance =
+    static_cast<double>(WHEEL_DELTA) * 100.0;
+
+int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
+  if (!std::isfinite(logical_distance)) {
+    return 0;
+  }
+  const double direction = invert ? -1.0 : 1.0;
+  const double scaled =
+      logical_distance * direction * kWindowsWheelSensitivity;
+  const double clamped = (std::clamp)(
+      scaled, -kMaxWindowsWheelDistance, kMaxWindowsWheelDistance);
+  return static_cast<int>(std::lround(clamped));
+}
 
 LRESULT CALLBACK CursorReseedSubclassProc(
     HWND window,
@@ -1370,10 +1385,8 @@ void performMouseScroll(double dx, double dy) {
     // RD_MOUSE_SCROLL uses logical page direction: +x right, +y down.
     // Win32 horizontal wheel uses the same sign, while vertical wheel uses
     // the physical wheel direction (+ is forward/page-up), so y is inverted.
-    const int horizontal_distance = static_cast<int>(
-        std::lround(dx * kWindowsWheelUnitsPerLogicalScrollUnit));
-    const int vertical_distance = static_cast<int>(
-        std::lround(-dy * kWindowsWheelUnitsPerLogicalScrollUnit));
+    const int horizontal_distance = logicalScrollToWindowsWheel(dx, false);
+    const int vertical_distance = logicalScrollToWindowsWheel(dy, true);
 
     if (horizontal_distance != 0) {
         hscroll(horizontal_distance);


### PR DESCRIPTION
## What changed

- Define `performMouseScroll(dx, dy)` as a canonical logical scroll contract: positive x scrolls right and positive y scrolls down.
- Convert logical deltas to Win32 native wheel semantics at the Windows host boundary.
- Set the Windows wheel-unit scale to 1.5 and round after scaling.
- Convert both axes to CoreGraphics wheel direction on macOS.
- Convert logical vertical deltas to Linux `REL_WHEEL` direction and cover the mapping with a native unit test.

## Why

Flutter emits logical page-scroll deltas, while Win32 `SendInput`, CoreGraphics wheel events, and Linux `REL_WHEEL` use platform-native wheel conventions. Passing the logical vertical sign through unchanged made Windows-to-Windows scrolling run backwards and left host behavior inconsistent across platforms.

## Impact

Viewer-to-host scroll packets retain one platform-neutral meaning. Platform-specific sign and unit conversion is isolated in the native host adapter.

## Validation

- `flutter test` in `hardware_simulator` — passed
- Main app `flutter analyze` — no issues
- 82 targeted remote desktop tests — passed
- `flutter build windows --release` — passed, including this plugin's Windows implementation
- Windows-to-Windows manual test — verified Flutter `dy = -80` is received unchanged and injected as Win32 `+120`
- Linux native direction test added; not executed on this Windows machine

The macOS source change was reviewed against the CoreGraphics mapping but was not compiled on this Windows machine.