### PR TITLE
fix(windows): move scroll scaling to Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Define a cross-platform logical scroll contract and convert it at each
   native host boundary.
-* Reduce the empirical Windows scroll sensitivity from 2.0 to 1.5.
+* Move Windows scroll magnitude normalization to the Dart host layer; the
+  native adapter now applies direction and safety clamping only.
 
 ## 0.0.1
 

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -51,9 +51,8 @@ constexpr ULONG_PTR kCursorReseedExtraInfo =
     static_cast<ULONG_PTR>(0x43505052);  // "CPPR"
 constexpr UINT_PTR kCursorReseedSubclassId =
     static_cast<UINT_PTR>(0x43505052);
-// Empirical tuning: maps Flutter page-scroll deltas to the desired Win32
-// wheel speed while preserving the logical protocol value on the wire.
-constexpr double kWindowsWheelSensitivity = 1.5;
+// Dart normalizes platform-specific scroll magnitudes. The native adapter only
+// converts the logical page direction and clamps it to a safe Win32 range.
 constexpr double kMaxWindowsWheelDistance =
     static_cast<double>(WHEEL_DELTA) * 100.0;
 
@@ -62,8 +61,7 @@ int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
     return 0;
   }
   const double direction = invert ? -1.0 : 1.0;
-  const double scaled =
-      logical_distance * direction * kWindowsWheelSensitivity;
+  const double scaled = logical_distance * direction;
   const double clamped = (std::clamp)(
       scaled, -kMaxWindowsWheelDistance, kMaxWindowsWheelDistance);
   return static_cast<int>(std::lround(clamped));


### PR DESCRIPTION
## What changed

- Remove the Windows native `1.5` wheel magnitude multiplier.
- Keep the native adapter responsible only for axis direction, safe clamping, and Win32 injection.

## Why

The CloudPlayPlus Dart Host now applies source-platform-aware mouse-wheel normalization. Keeping the empirical multiplier in the native adapter would double-scale Windows input and prevents macOS mouse wheels from being normalized to a full Windows `WHEEL_DELTA` detent.

## Impact

This change must ship with the matching CloudPlayPlus client protocol update. It is intentionally not a standalone behavior change.

## Validation

- Parent CloudPlayPlus full Flutter test suite: 732 tests passed.
- Parent `flutter analyze --no-pub`: no issues.
- Windows native compilation still needs CI/Windows validation.
