### PR TITLE
feat(macos): expose native trackpad scroll events

### DIFF
--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -24,4 +24,13 @@ class RunnerTests: XCTestCase {
     waitForExpectations(timeout: 1)
   }
 
+  func testTrackpadPointDeltaUsesLogicalInverseAtOneToOneScale() {
+    XCTAssertEqual(HardwareSimulatorPlugin.nativeTrackpadPointDelta(-30), 30)
+    XCTAssertEqual(HardwareSimulatorPlugin.nativeTrackpadPointDelta(30), -30)
+    XCTAssertEqual(HardwareSimulatorPlugin.nativeTrackpadPointDelta(-0.1), 1)
+    XCTAssertEqual(HardwareSimulatorPlugin.nativeTrackpadPointDelta(0.1), -1)
+    XCTAssertEqual(HardwareSimulatorPlugin.nativeTrackpadPointDelta(0), 0)
+    XCTAssertNil(HardwareSimulatorPlugin.nativeTrackpadPointDelta(.nan))
+  }
+
 }

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -1,6 +1,10 @@
 import 'hardware_simulator_platform_interface.dart';
 export 'hardware_simulator_platform_interface.dart'
-    show DisplayCountChangedCallback;
+    show
+        DisplayCountChangedCallback,
+        TrackpadScrollCallback,
+        TrackpadScrollEvent,
+        TrackpadScrollPhase;
 import 'display_data.dart';
 
 /// Snapshot of the macOS TCC permissions relevant to remote-control hosting.
@@ -224,6 +228,16 @@ class HardwareSimulator {
 
   static void removeCursorWheel(CursorWheelCallback callback) {
     HardwareSimulatorPlatform.instance.removeCursorWheel(callback);
+  }
+
+  /// Registers for precision trackpad scrolling captured by the native
+  /// platform embedder.
+  static void addTrackpadScroll(TrackpadScrollCallback callback) {
+    HardwareSimulatorPlatform.instance.addTrackpadScroll(callback);
+  }
+
+  static void removeTrackpadScroll(TrackpadScrollCallback callback) {
+    HardwareSimulatorPlatform.instance.removeTrackpadScroll(callback);
   }
 
   // ignore: constant_identifier_names

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -73,6 +73,25 @@ class HWMouse {
   void performMouseScroll(double dx, double dy) {
     HardwareSimulatorPlatform.instance.performMouseScroll(dx, dy);
   }
+
+  /// Injects a continuous precision-trackpad delta without discarding
+  /// fractional pixels.
+  ///
+  /// Positive x scrolls right and positive y scrolls down. Platforms without
+  /// a native precise path may fall back to ordinary scroll injection.
+  void performTrackpadScroll(
+    double dx,
+    double dy, {
+    TrackpadScrollPhase phase = TrackpadScrollPhase.none,
+    bool isMomentum = false,
+  }) {
+    HardwareSimulatorPlatform.instance.performTrackpadScroll(
+      dx,
+      dy,
+      phase: phase,
+      isMomentum: isMomentum,
+    );
+  }
 }
 
 class GameController {

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -45,7 +45,9 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
             phase: _trackpadScrollPhase(arguments['phase']),
             isMomentum: arguments['isMomentum'] == true,
           );
-          for (var callback in trackpadScrollCallbacks) {
+          for (final callback in List<TrackpadScrollCallback>.of(
+            trackpadScrollCallbacks,
+          )) {
             callback(event);
           }
         }
@@ -263,6 +265,7 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   @override
   void addTrackpadScroll(TrackpadScrollCallback callback) {
     if (!isinitialized) init();
+    if (trackpadScrollCallbacks.contains(callback)) return;
     final shouldStartCapture = trackpadScrollCallbacks.isEmpty;
     trackpadScrollCallbacks.add(callback);
     if (shouldStartCapture) {

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -34,6 +34,21 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
         for (var callback in cursorWheelCallbacks) {
           callback(call.arguments['dx'], call.arguments['dy']);
         }
+      } else if (call.method == "onTrackpadScroll") {
+        final arguments = call.arguments;
+        if (arguments is Map) {
+          final event = TrackpadScrollEvent(
+            x: _asDouble(arguments['x']),
+            y: _asDouble(arguments['y']),
+            deltaX: _asDouble(arguments['dx']),
+            deltaY: _asDouble(arguments['dy']),
+            phase: _trackpadScrollPhase(arguments['phase']),
+            isMomentum: arguments['isMomentum'] == true,
+          );
+          for (var callback in trackpadScrollCallbacks) {
+            callback(event);
+          }
+        }
       } else if (call.method == "onCursorImageMessage") {
         int callbackID = call.arguments['callbackID'];
         if (cursorImageCallbacks.containsKey(callbackID)) {
@@ -243,6 +258,46 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
     cursorWheelCallbacks.remove(callback);
   }
 
+  final List<TrackpadScrollCallback> trackpadScrollCallbacks = [];
+
+  @override
+  void addTrackpadScroll(TrackpadScrollCallback callback) {
+    if (!isinitialized) init();
+    final shouldStartCapture = trackpadScrollCallbacks.isEmpty;
+    trackpadScrollCallbacks.add(callback);
+    if (shouldStartCapture) {
+      unawaited(startTrackpadScrollCapture());
+    }
+  }
+
+  @override
+  void removeTrackpadScroll(TrackpadScrollCallback callback) {
+    final removed = trackpadScrollCallbacks.remove(callback);
+    if (removed && trackpadScrollCallbacks.isEmpty) {
+      unawaited(stopTrackpadScrollCapture());
+    }
+  }
+
+  @override
+  Future<bool> startTrackpadScrollCapture() async {
+    try {
+      final supported = await methodChannel
+          .invokeMethod<Object?>('startTrackpadScrollCapture');
+      return supported == true;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  @override
+  Future<void> stopTrackpadScrollCapture() async {
+    try {
+      await methodChannel.invokeMethod<void>('stopTrackpadScrollCapture');
+    } on MissingPluginException {
+      return;
+    }
+  }
+
   final Map<int, CursorImageUpdatedCallback> cursorImageCallbacks = {};
   final Map<int, CursorPositionUpdatedCallback> cursorPositionCallbacks = {};
   final Map<int, DisplayCountChangedCallback> displayCountCallbacks = {};
@@ -373,6 +428,22 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
       'dx': dx,
       'dy': dy,
     });
+  }
+
+  static double _asDouble(Object? value) {
+    return value is num ? value.toDouble() : 0;
+  }
+
+  static TrackpadScrollPhase _trackpadScrollPhase(Object? value) {
+    return switch (value) {
+      'mayBegin' => TrackpadScrollPhase.mayBegin,
+      'began' => TrackpadScrollPhase.began,
+      'changed' => TrackpadScrollPhase.changed,
+      'stationary' => TrackpadScrollPhase.stationary,
+      'ended' => TrackpadScrollPhase.ended,
+      'cancelled' => TrackpadScrollPhase.cancelled,
+      _ => TrackpadScrollPhase.none,
+    };
   }
 
   @override

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -440,12 +440,16 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
     TrackpadScrollPhase phase = TrackpadScrollPhase.none,
     bool isMomentum = false,
   }) async {
-    await methodChannel.invokeMethod('trackpadScroll', {
-      'dx': dx,
-      'dy': dy,
-      'phase': phase.name,
-      'isMomentum': isMomentum,
-    });
+    try {
+      await methodChannel.invokeMethod('trackpadScroll', {
+        'dx': dx,
+        'dy': dy,
+        'phase': phase.name,
+        'isMomentum': isMomentum,
+      });
+    } on MissingPluginException {
+      await performMouseScroll(dx, dy);
+    }
   }
 
   static double _asDouble(Object? value) {

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -433,6 +433,21 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
     });
   }
 
+  @override
+  Future<void> performTrackpadScroll(
+    double dx,
+    double dy, {
+    TrackpadScrollPhase phase = TrackpadScrollPhase.none,
+    bool isMomentum = false,
+  }) async {
+    await methodChannel.invokeMethod('trackpadScroll', {
+      'dx': dx,
+      'dy': dy,
+      'phase': phase.name,
+      'isMomentum': isMomentum,
+    });
+  }
+
   static double _asDouble(Object? value) {
     return value is num ? value.toDouble() : 0;
   }

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -33,7 +33,9 @@ enum TrackpadScrollPhase {
 ///
 /// [x] and [y] use Flutter view coordinates. Deltas use page direction:
 /// positive x scrolls right and positive y scrolls down. Every platform
-/// implementation normalizes its native convention to this contract.
+/// implementation normalizes its native convention to this contract. The
+/// resulting page direction follows the user's platform scroll-direction
+/// preference.
 @immutable
 class TrackpadScrollEvent {
   const TrackpadScrollEvent({
@@ -191,6 +193,7 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   /// Registers for native precision trackpad scrolling when implemented.
   void addTrackpadScroll(TrackpadScrollCallback callback) {}
 
+  /// Removes a previously registered precision trackpad listener.
   void removeTrackpadScroll(TrackpadScrollCallback callback) {}
 
   /// Starts native precision trackpad capture.
@@ -200,6 +203,7 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     return false;
   }
 
+  /// Stops native precision trackpad capture when implemented.
   Future<void> stopTrackpadScrollCapture() async {}
 
   void addCursorImageUpdated(

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -274,6 +274,17 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('performMouseScroll() has not been implemented.');
   }
 
+  /// Injects logical continuous trackpad scrolling while preserving
+  /// fractional pixels.
+  Future<void> performTrackpadScroll(
+    double dx,
+    double dy, {
+    TrackpadScrollPhase phase = TrackpadScrollPhase.none,
+    bool isMomentum = false,
+  }) {
+    return performMouseScroll(dx, dy);
+  }
+
   // Touch event simulation
   Future<void> performTouchEvent(
       double x, double y, int touchId, bool isDown, int screenId) async {

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -11,11 +11,47 @@ typedef CursorPressedCallback = void Function(int button, bool isDown);
 typedef KeyboardPressedCallback = void Function(int button, bool isDown);
 typedef KeyBlockedCallback = void Function(int keyCode, bool isDown);
 typedef CursorWheelCallback = void Function(double deltaX, double deltaY);
+typedef TrackpadScrollCallback = void Function(TrackpadScrollEvent event);
 typedef CursorImageUpdatedCallback = void Function(
     int message, int messageInfo, Uint8List cursorImage);
 typedef CursorPositionUpdatedCallback = void Function(
     int message, int screenId, double xPercent, double yPercent);
 typedef DisplayCountChangedCallback = void Function(int displayCount);
+
+/// Platform-independent lifecycle for a native precision trackpad gesture.
+enum TrackpadScrollPhase {
+  none,
+  mayBegin,
+  began,
+  changed,
+  stationary,
+  ended,
+  cancelled,
+}
+
+/// A precision trackpad scroll event captured by the platform embedder.
+///
+/// [x] and [y] use Flutter view coordinates. Deltas use page direction:
+/// positive x scrolls right and positive y scrolls down. Every platform
+/// implementation normalizes its native convention to this contract.
+@immutable
+class TrackpadScrollEvent {
+  const TrackpadScrollEvent({
+    required this.x,
+    required this.y,
+    required this.deltaX,
+    required this.deltaY,
+    required this.phase,
+    required this.isMomentum,
+  });
+
+  final double x;
+  final double y;
+  final double deltaX;
+  final double deltaY;
+  final TrackpadScrollPhase phase;
+  final bool isMomentum;
+}
 
 abstract class HardwareSimulatorPlatform extends PlatformInterface {
   /// Constructs a HardwareSimulatorPlatform.
@@ -152,6 +188,20 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('removeCursorWheel() has not been implemented.');
   }
 
+  /// Registers for native precision trackpad scrolling when implemented.
+  void addTrackpadScroll(TrackpadScrollCallback callback) {}
+
+  void removeTrackpadScroll(TrackpadScrollCallback callback) {}
+
+  /// Starts native precision trackpad capture.
+  ///
+  /// Returns false on platforms that have not implemented the unified source.
+  Future<bool> startTrackpadScrollCapture() async {
+    return false;
+  }
+
+  Future<void> stopTrackpadScrollCapture() async {}
+
   void addCursorImageUpdated(
       CursorImageUpdatedCallback callback, int callbackId, bool hookAll) {
     throw UnimplementedError(
@@ -262,7 +312,8 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   }
 
   Future<bool> ensureConsoleForDisplay() {
-    throw UnimplementedError('ensureConsoleForDisplay() has not been implemented.');
+    throw UnimplementedError(
+        'ensureConsoleForDisplay() has not been implemented.');
   }
 
   Future<bool> initParsecVdd() {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -15,6 +15,8 @@ class CursorConstants {
 
 public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var methodChannel: FlutterMethodChannel?
+  private weak var flutterView: NSView?
+  private var trackpadScrollMonitor: Any?
   private var defaultCursorHasher: CursorHasher?
   private var currentScreenId: Int = 0
   private var lastMouseClickButtonId: Int?
@@ -57,6 +59,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let channel = FlutterMethodChannel(name: "hardware_simulator", binaryMessenger: registrar.messenger)
     let instance = HardwareSimulatorPlugin()
     instance.methodChannel = channel
+    instance.flutterView = registrar.view
     instance.defaultCursorHasher = CursorHasher()
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
     instance.registerMacTerminationObserver()
@@ -65,12 +68,65 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   deinit {
+    stopTrackpadScrollCapture()
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
     if let macTerminationObserver {
       NotificationCenter.default.removeObserver(macTerminationObserver)
     }
     restoreMacDisplaysBeforeExit()
 #endif
+  }
+
+  private func startTrackpadScrollCapture() {
+    guard trackpadScrollMonitor == nil else { return }
+    trackpadScrollMonitor = NSEvent.addLocalMonitorForEvents(
+      matching: .scrollWheel
+    ) { [weak self] event in
+      self?.handleTrackpadScroll(event)
+      return event
+    }
+  }
+
+  private func stopTrackpadScrollCapture() {
+    guard let trackpadScrollMonitor else { return }
+    NSEvent.removeMonitor(trackpadScrollMonitor)
+    self.trackpadScrollMonitor = nil
+  }
+
+  private func handleTrackpadScroll(_ event: NSEvent) {
+    guard event.hasPreciseScrollingDeltas else { return }
+    guard let flutterView, event.window === flutterView.window else { return }
+
+    let isMomentum = event.momentumPhase.rawValue != 0
+    let eventPhase = isMomentum ? event.momentumPhase : event.phase
+    guard eventPhase.rawValue != 0 else { return }
+
+    let point = flutterView.convert(event.locationInWindow, from: nil)
+    let flutterY = flutterView.isFlipped
+      ? point.y
+      : flutterView.bounds.height - point.y
+    methodChannel?.invokeMethod(
+      "onTrackpadScroll",
+      arguments: [
+        "x": point.x,
+        "y": flutterY,
+        // AppKit reports gesture direction; the plugin API uses page direction.
+        "dx": -event.scrollingDeltaX,
+        "dy": -event.scrollingDeltaY,
+        "phase": trackpadScrollPhaseName(eventPhase),
+        "isMomentum": isMomentum,
+      ]
+    )
+  }
+
+  private func trackpadScrollPhaseName(_ phase: NSEvent.Phase) -> String {
+    if phase.contains(.cancelled) { return "cancelled" }
+    if phase.contains(.ended) { return "ended" }
+    if phase.contains(.began) { return "began" }
+    if phase.contains(.mayBegin) { return "mayBegin" }
+    if phase.contains(.stationary) { return "stationary" }
+    if phase.contains(.changed) { return "changed" }
+    return "none"
   }
 
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
@@ -2305,6 +2361,12 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     switch call.method {
     case "getPlatformVersion":
       result("macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
+    case "startTrackpadScrollCapture":
+      startTrackpadScrollCapture()
+      result(true)
+    case "stopTrackpadScrollCapture":
+      stopTrackpadScrollCapture()
+      result(nil)
     case "checkMacOSPermissions":
       // Reports the *current process's* live TCC status. Does NOT prompt.
       // - screenCapture: needed to grab the screen (ScreenCaptureKit / CGDisplayStream)

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1935,6 +1935,114 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
   }
 
+  private func nativeTrackpadPointDelta(_ logicalDelta: Double) -> Int32? {
+      guard logicalDelta.isFinite else { return nil }
+      if logicalDelta == 0 { return 0 }
+
+      // A local macOS event measured as scrollingDelta=0.1 carries a
+      // wheel/point axis of one and a 16.16 fixed-point delta of 0.1.
+      // Rebuild both representations instead of rounding the precise value.
+      var rounded = (logicalDelta * 10).rounded()
+      if rounded == 0 {
+          rounded = logicalDelta.isLess(than: 0) ? -1 : 1
+      }
+      let clamped = min(
+          max(rounded, Double(Int32.min)),
+          Double(Int32.max)
+      )
+      return Int32(clamped)
+  }
+
+  private func nativeTrackpadScrollPhase(_ phase: String) -> Int64 {
+      switch phase {
+      case "mayBegin":
+          return Int64(CGScrollPhase.mayBegin.rawValue)
+      case "began":
+          return Int64(CGScrollPhase.began.rawValue)
+      case "changed", "stationary":
+          return Int64(CGScrollPhase.changed.rawValue)
+      case "ended":
+          return Int64(CGScrollPhase.ended.rawValue)
+      case "cancelled":
+          return Int64(CGScrollPhase.cancelled.rawValue)
+      default:
+          return 0
+      }
+  }
+
+  private func nativeTrackpadMomentumPhase(_ phase: String) -> Int64 {
+      switch phase {
+      case "mayBegin", "began":
+          return Int64(CGMomentumScrollPhase.begin.rawValue)
+      case "changed", "stationary":
+          return Int64(CGMomentumScrollPhase.continuous.rawValue)
+      case "ended", "cancelled":
+          return Int64(CGMomentumScrollPhase.end.rawValue)
+      default:
+          return Int64(CGMomentumScrollPhase.none.rawValue)
+      }
+  }
+
+  func performTrackpadScroll(
+      dx: Double,
+      dy: Double,
+      phase: String,
+      isMomentum: Bool
+  ) {
+      guard
+          let horizontalPoint = nativeTrackpadPointDelta(dx),
+          let verticalPoint = nativeTrackpadPointDelta(dy)
+      else {
+          return
+      }
+
+      let eventSource = CGEventSource(stateID: .hidSystemState)
+      let wheelCount: UInt32 = horizontalPoint != 0 ? 2 : 1
+      guard let scrollEvent = CGEvent(
+          scrollWheelEvent2Source: eventSource,
+          units: .pixel,
+          wheelCount: wheelCount,
+          wheel1: verticalPoint,
+          wheel2: horizontalPoint,
+          wheel3: 0
+      ) else {
+          return
+      }
+
+      // RD trackpad deltas use logical page direction. A native macOS precise
+      // event carries the opposite gesture-direction value in its 16.16
+      // fixed-point fields, while wheel/point axes retain page direction.
+      scrollEvent.setDoubleValueField(
+          .scrollWheelEventFixedPtDeltaAxis1,
+          value: -dy
+      )
+      scrollEvent.setDoubleValueField(
+          .scrollWheelEventFixedPtDeltaAxis2,
+          value: -dx
+      )
+      scrollEvent.setIntegerValueField(
+          .scrollWheelEventPointDeltaAxis1,
+          value: Int64(verticalPoint)
+      )
+      scrollEvent.setIntegerValueField(
+          .scrollWheelEventPointDeltaAxis2,
+          value: Int64(horizontalPoint)
+      )
+      scrollEvent.setIntegerValueField(
+          .scrollWheelEventIsContinuous,
+          value: 1
+      )
+      scrollEvent.setIntegerValueField(
+          .scrollWheelEventScrollPhase,
+          value: isMomentum ? 0 : nativeTrackpadScrollPhase(phase)
+      )
+      scrollEvent.setIntegerValueField(
+          .scrollWheelEventMomentumPhase,
+          value: isMomentum ? nativeTrackpadMomentumPhase(phase) : 0
+      )
+      scrollEvent.post(tap: .cghidEventTap)
+  }
+
   func performMouseMoveToWindowPosition(percentx: Double, percenty: Double) {
       // Get the current Flutter app's main window
       guard let mainWindow = NSApplication.shared.mainWindow ?? NSApplication.shared.windows.first else {
@@ -2643,6 +2751,22 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         result(nil) // 表示成功执行，不返回值
       } else {
         result(FlutterError(code: "BAD_ARGS", message: "Missing or incorrect arguments for Mouse Scroll", details: nil))
+      }
+    case "trackpadScroll":
+      if let args = call.arguments as? [String: Any],
+        let dx = args["dx"] as? Double,
+        let dy = args["dy"] as? Double,
+        let phase = args["phase"] as? String,
+        let isMomentum = args["isMomentum"] as? Bool {
+        performTrackpadScroll(
+          dx: dx,
+          dy: dy,
+          phase: phase,
+          isMomentum: isMomentum
+        )
+        result(nil)
+      } else {
+        result(FlutterError(code: "BAD_ARGS", message: "Missing or incorrect arguments for Trackpad Scroll", details: nil))
       }
     case "mouseMoveToWindowPosition":
       if let args = call.arguments as? [String: Any],

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1935,16 +1935,16 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       }
   }
 
-  private func nativeTrackpadPointDelta(_ logicalDelta: Double) -> Int32? {
+  static func nativeTrackpadPointDelta(_ logicalDelta: Double) -> Int32? {
       guard logicalDelta.isFinite else { return nil }
       if logicalDelta == 0 { return 0 }
 
-      // A local macOS event measured as scrollingDelta=0.1 carries a
-      // wheel/point axis of one and a 16.16 fixed-point delta of 0.1.
-      // Rebuild both representations instead of rounding the precise value.
-      var rounded = (logicalDelta * 10).rounded()
+      // CoreGraphics wheel/point axes use the opposite sign from our logical
+      // page direction. Preserve their 1:1 magnitude for whole pixels; only
+      // clamp a non-zero subpixel delta to the smallest representable integer.
+      var rounded = (-logicalDelta).rounded()
       if rounded == 0 {
-          rounded = logicalDelta.isLess(than: 0) ? -1 : 1
+          rounded = logicalDelta.isLess(than: 0) ? 1 : -1
       }
       let clamped = min(
           max(rounded, Double(Int32.min)),
@@ -1990,8 +1990,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       isMomentum: Bool
   ) {
       guard
-          let horizontalPoint = nativeTrackpadPointDelta(dx),
-          let verticalPoint = nativeTrackpadPointDelta(dy)
+          let horizontalPoint = Self.nativeTrackpadPointDelta(dx),
+          let verticalPoint = Self.nativeTrackpadPointDelta(dy)
       else {
           return
       }
@@ -2009,9 +2009,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           return
       }
 
-      // RD trackpad deltas use logical page direction. A native macOS precise
-      // event carries the opposite gesture-direction value in its 16.16
-      // fixed-point fields, while wheel/point axes retain page direction.
+      // RD trackpad deltas use logical page direction. CoreGraphics fields use
+      // the opposite gesture/device direction. Fixed-point preserves the exact
+      // fraction; point/wheel fields provide the closest non-zero integer.
       scrollEvent.setDoubleValueField(
           .scrollWheelEventFixedPtDeltaAxis1,
           value: -dy

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -15,6 +15,7 @@ class CursorConstants {
 
 public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var methodChannel: FlutterMethodChannel?
+  private weak var registrar: FlutterPluginRegistrar?
   private weak var flutterView: NSView?
   private var trackpadScrollMonitor: Any?
   private var defaultCursorHasher: CursorHasher?
@@ -59,7 +60,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     let channel = FlutterMethodChannel(name: "hardware_simulator", binaryMessenger: registrar.messenger)
     let instance = HardwareSimulatorPlugin()
     instance.methodChannel = channel
-    instance.flutterView = registrar.view
+    instance.registrar = registrar
     instance.defaultCursorHasher = CursorHasher()
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
     instance.registerMacTerminationObserver()
@@ -77,14 +78,19 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 #endif
   }
 
-  private func startTrackpadScrollCapture() {
-    guard trackpadScrollMonitor == nil else { return }
+  private func startTrackpadScrollCapture() -> Bool {
+    if trackpadScrollMonitor != nil {
+      return flutterView != nil
+    }
+    flutterView = registrar?.view ?? registrar?.viewController?.view
+    guard flutterView != nil else { return false }
     trackpadScrollMonitor = NSEvent.addLocalMonitorForEvents(
       matching: .scrollWheel
     ) { [weak self] event in
       self?.handleTrackpadScroll(event)
       return event
     }
+    return true
   }
 
   private func stopTrackpadScrollCapture() {
@@ -95,6 +101,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func handleTrackpadScroll(_ event: NSEvent) {
     guard event.hasPreciseScrollingDeltas else { return }
+    if flutterView?.window !== event.window {
+      flutterView = registrar?.view ?? registrar?.viewController?.view
+    }
     guard let flutterView, event.window === flutterView.window else { return }
 
     let isMomentum = event.momentumPhase.rawValue != 0
@@ -2362,8 +2371,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     case "getPlatformVersion":
       result("macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
     case "startTrackpadScrollCapture":
-      startTrackpadScrollCapture()
-      result(true)
+      result(startTrackpadScrollCapture())
     case "stopTrackpadScrollCapture":
       stopTrackpadScrollCapture()
       result(nil)

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -94,9 +94,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private func stopTrackpadScrollCapture() {
-    guard let trackpadScrollMonitor else { return }
-    NSEvent.removeMonitor(trackpadScrollMonitor)
+    if let trackpadScrollMonitor {
+      NSEvent.removeMonitor(trackpadScrollMonitor)
+    }
     self.trackpadScrollMonitor = nil
+    flutterView = nil
   }
 
   private func handleTrackpadScroll(_ event: NSEvent) {

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -78,6 +78,33 @@ void main() {
     });
   });
 
+  test('performTrackpadScroll falls back when native method is missing',
+      () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        if (methodCall.method == 'trackpadScroll') {
+          throw MissingPluginException();
+        }
+        return null;
+      },
+    );
+
+    await platform.performTrackpadScroll(0.125, -0.375);
+
+    expect(calls.map((call) => call.method), [
+      'trackpadScroll',
+      'mouseScroll',
+    ]);
+    expect(calls.last.arguments, {
+      'dx': 0.125,
+      'dy': -0.375,
+    });
+  });
+
   test('unlockCursorAndReseed sends normalized window position', () async {
     final calls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -50,6 +50,34 @@ void main() {
     });
   });
 
+  test('performTrackpadScroll preserves fractional deltas', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        return null;
+      },
+    );
+
+    await platform.performTrackpadScroll(
+      0.125,
+      -0.375,
+      phase: TrackpadScrollPhase.changed,
+      isMomentum: true,
+    );
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'trackpadScroll');
+    expect(calls.single.arguments, {
+      'dx': 0.125,
+      'dy': -0.375,
+      'phase': 'changed',
+      'isMomentum': true,
+    });
+  });
+
   test('unlockCursorAndReseed sends normalized window position', () async {
     final calls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -99,6 +99,7 @@ void main() {
     void firstListener(TrackpadScrollEvent _) {}
     void secondListener(TrackpadScrollEvent _) {}
     platform.addTrackpadScroll(firstListener);
+    platform.addTrackpadScroll(firstListener);
     platform.addTrackpadScroll(secondListener);
     await Future<void>.delayed(Duration.zero);
     platform.removeTrackpadScroll(firstListener);
@@ -116,7 +117,12 @@ void main() {
 
   test('decodes native trackpad scroll events', () async {
     TrackpadScrollEvent? received;
-    platform.addTrackpadScroll((event) => received = event);
+    late TrackpadScrollCallback listener;
+    listener = (event) {
+      received = event;
+      platform.removeTrackpadScroll(listener);
+    };
+    platform.addTrackpadScroll(listener);
 
     await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage(
@@ -141,5 +147,6 @@ void main() {
     expect(received!.deltaY, -4);
     expect(received!.phase, TrackpadScrollPhase.changed);
     expect(received!.isMomentum, isTrue);
+    await Future<void>.delayed(Duration.zero);
   });
 }

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -84,4 +84,62 @@ void main() {
 
     expect(calls, isEmpty);
   });
+
+  test('first and last trackpad listeners manage native capture', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        return methodCall.method == 'startTrackpadScrollCapture';
+      },
+    );
+
+    void firstListener(TrackpadScrollEvent _) {}
+    void secondListener(TrackpadScrollEvent _) {}
+    platform.addTrackpadScroll(firstListener);
+    platform.addTrackpadScroll(secondListener);
+    await Future<void>.delayed(Duration.zero);
+    platform.removeTrackpadScroll(firstListener);
+    await Future<void>.delayed(Duration.zero);
+    expect(calls.map((call) => call.method), ['startTrackpadScrollCapture']);
+
+    platform.removeTrackpadScroll(secondListener);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      calls.map((call) => call.method),
+      ['startTrackpadScrollCapture', 'stopTrackpadScrollCapture'],
+    );
+  });
+
+  test('decodes native trackpad scroll events', () async {
+    TrackpadScrollEvent? received;
+    platform.addTrackpadScroll((event) => received = event);
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      'hardware_simulator',
+      const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('onTrackpadScroll', <String, dynamic>{
+          'x': 125,
+          'y': 250.5,
+          'dx': 1.25,
+          'dy': -4,
+          'phase': 'changed',
+          'isMomentum': true,
+        }),
+      ),
+      null,
+    );
+
+    expect(received, isNotNull);
+    expect(received!.x, 125);
+    expect(received!.y, 250.5);
+    expect(received!.deltaX, 1.25);
+    expect(received!.deltaY, -4);
+    expect(received!.phase, TrackpadScrollPhase.changed);
+    expect(received!.isMomentum, isTrue);
+  });
 }

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND PLUGIN_SOURCES
   "gamecontroller_manager.h"
   "notification_window.cc"
   "notification_window.h"
+  "trackpad_scroll_accumulator.h"
   "virtual_display.cc"
   "virtual_display.h"
   "virtual_display_control.cc"

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -56,12 +56,6 @@ constexpr UINT_PTR kCursorReseedSubclassId =
 // converts the logical page direction and clamps it to a safe Win32 range.
 constexpr double kMaxWindowsWheelDistance =
     static_cast<double>(WHEEL_DELTA) * 100.0;
-// Chromium's legacy Windows wheel path maps one 120-unit detent to 100 CSS
-// pixels with the default three-line setting. Convert native macOS trackpad
-// pixels into that Win32 unit space so cumulative page movement stays 1:1.
-constexpr double kWindowsTrackpadWheelUnitsPerPixel =
-    static_cast<double>(WHEEL_DELTA) / 100.0;
-
 int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
   if (!std::isfinite(logical_distance)) {
     return 0;
@@ -1405,11 +1399,11 @@ void performTrackpadScroll(double dx, double dy) {
     // Windows 10 has no public precision-touchpad injection API. Replay each
     // native trackpad frame as an ordinary high-resolution wheel event. The
     // legacy API is integral, so each axis carries its fractional wheel-unit
-    // remainder forward to preserve cumulative page distance.
+    // remainder forward. Cross-platform magnitude scaling belongs to Dart.
     thread_local TrackpadScrollAccumulator horizontal_accumulator(
-        kWindowsTrackpadWheelUnitsPerPixel, kMaxWindowsWheelDistance);
+        kMaxWindowsWheelDistance);
     thread_local TrackpadScrollAccumulator vertical_accumulator(
-        kWindowsTrackpadWheelUnitsPerPixel, kMaxWindowsWheelDistance);
+        kMaxWindowsWheelDistance);
     const int horizontal_distance =
         horizontal_accumulator.Convert(dx, false);
     const int vertical_distance =

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -67,6 +67,22 @@ int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
   return static_cast<int>(std::lround(clamped));
 }
 
+int logicalTrackpadScrollToWindowsWheel(
+    double logical_distance,
+    bool invert) {
+  if (!std::isfinite(logical_distance)) {
+    return 0;
+  }
+  const double direction = invert ? -1.0 : 1.0;
+  const double converted = logical_distance * direction;
+  const double clamped = (std::clamp)(
+      converted, -kMaxWindowsWheelDistance, kMaxWindowsWheelDistance);
+  // Win32 MOUSEINPUT::mouseData is integral. The trackpad path deliberately
+  // sends the canonical 1x delta directly at that API boundary: no mouse-wheel
+  // sensitivity multiplier, fractional accumulator, or nearest-value rounding.
+  return static_cast<int>(clamped);
+}
+
 LRESULT CALLBACK CursorReseedSubclassProc(
     HWND window,
     UINT message,
@@ -1395,6 +1411,23 @@ void performMouseScroll(double dx, double dy) {
     }
 }
 
+void performTrackpadScroll(double dx, double dy) {
+    // Windows 10 has no public precision-touchpad injection API. Replay each
+    // native trackpad frame as an ordinary high-resolution wheel event while
+    // preserving the canonical 1x magnitude.
+    const int horizontal_distance =
+        logicalTrackpadScrollToWindowsWheel(dx, false);
+    const int vertical_distance =
+        logicalTrackpadScrollToWindowsWheel(dy, true);
+
+    if (horizontal_distance != 0) {
+        hscroll(horizontal_distance);
+    }
+    if (vertical_distance != 0) {
+        scroll(vertical_distance);
+    }
+}
+
 std::wstring stringToWstring(const std::string& str) {
     int wideCharLen = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
     if (wideCharLen <= 0) return L"";
@@ -1464,6 +1497,13 @@ void HardwareSimulatorPlugin::HandleMethodCall(
         auto dx = (args->find(flutter::EncodableValue("dx")))->second;
         auto dy = (args->find(flutter::EncodableValue("dy")))->second;
         performMouseScroll(
+            std::get<double>(dx),
+            std::get<double>(dy));
+        result->Success(nullptr);
+  } else if (method_call.method_name().compare("trackpadScroll") == 0) {
+        auto dx = (args->find(flutter::EncodableValue("dx")))->second;
+        auto dy = (args->find(flutter::EncodableValue("dy")))->second;
+        performTrackpadScroll(
             std::get<double>(dx),
             std::get<double>(dy));
         result->Success(nullptr);

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -4,6 +4,7 @@
 #include "desktop_service_input_client.h"
 #include "gamecontroller_manager.h"
 #include "notification_window.h"
+#include "trackpad_scroll_accumulator.h"
 #include "virtual_display_control.h"
 #include "SmartKeyboardBlocker.h"
 
@@ -55,6 +56,11 @@ constexpr UINT_PTR kCursorReseedSubclassId =
 // converts the logical page direction and clamps it to a safe Win32 range.
 constexpr double kMaxWindowsWheelDistance =
     static_cast<double>(WHEEL_DELTA) * 100.0;
+// Chromium's legacy Windows wheel path maps one 120-unit detent to 100 CSS
+// pixels with the default three-line setting. Convert native macOS trackpad
+// pixels into that Win32 unit space so cumulative page movement stays 1:1.
+constexpr double kWindowsTrackpadWheelUnitsPerPixel =
+    static_cast<double>(WHEEL_DELTA) / 100.0;
 
 int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
   if (!std::isfinite(logical_distance)) {
@@ -65,22 +71,6 @@ int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
   const double clamped = (std::clamp)(
       scaled, -kMaxWindowsWheelDistance, kMaxWindowsWheelDistance);
   return static_cast<int>(std::lround(clamped));
-}
-
-int logicalTrackpadScrollToWindowsWheel(
-    double logical_distance,
-    bool invert) {
-  if (!std::isfinite(logical_distance)) {
-    return 0;
-  }
-  const double direction = invert ? -1.0 : 1.0;
-  const double converted = logical_distance * direction;
-  const double clamped = (std::clamp)(
-      converted, -kMaxWindowsWheelDistance, kMaxWindowsWheelDistance);
-  // Win32 MOUSEINPUT::mouseData is integral. The trackpad path deliberately
-  // sends the canonical 1x delta directly at that API boundary: no mouse-wheel
-  // sensitivity multiplier, fractional accumulator, or nearest-value rounding.
-  return static_cast<int>(clamped);
 }
 
 LRESULT CALLBACK CursorReseedSubclassProc(
@@ -1413,12 +1403,17 @@ void performMouseScroll(double dx, double dy) {
 
 void performTrackpadScroll(double dx, double dy) {
     // Windows 10 has no public precision-touchpad injection API. Replay each
-    // native trackpad frame as an ordinary high-resolution wheel event while
-    // preserving the canonical 1x magnitude.
+    // native trackpad frame as an ordinary high-resolution wheel event. The
+    // legacy API is integral, so each axis carries its fractional wheel-unit
+    // remainder forward to preserve cumulative page distance.
+    thread_local TrackpadScrollAccumulator horizontal_accumulator(
+        kWindowsTrackpadWheelUnitsPerPixel, kMaxWindowsWheelDistance);
+    thread_local TrackpadScrollAccumulator vertical_accumulator(
+        kWindowsTrackpadWheelUnitsPerPixel, kMaxWindowsWheelDistance);
     const int horizontal_distance =
-        logicalTrackpadScrollToWindowsWheel(dx, false);
+        horizontal_accumulator.Convert(dx, false);
     const int vertical_distance =
-        logicalTrackpadScrollToWindowsWheel(dy, true);
+        vertical_accumulator.Convert(dy, true);
 
     if (horizontal_distance != 0) {
         hscroll(horizontal_distance);

--- a/windows/test/hardware_simulator_plugin_test.cpp
+++ b/windows/test/hardware_simulator_plugin_test.cpp
@@ -40,21 +40,21 @@ TEST(HardwareSimulatorPlugin, GetPlatformVersion) {
   EXPECT_TRUE(result_string.rfind("Windows ", 0) == 0);
 }
 
-TEST(TrackpadScrollAccumulator, PreservesCumulativeBrowserPixelDistance) {
-  TrackpadScrollAccumulator accumulator(1.2, 12000);
+TEST(TrackpadScrollAccumulator, PreservesIntegralInputDistance) {
+  TrackpadScrollAccumulator accumulator(12000);
 
   EXPECT_EQ(accumulator.Convert(1, false), 1);
   EXPECT_EQ(accumulator.Convert(1, false), 1);
   EXPECT_EQ(accumulator.Convert(1, false), 1);
   EXPECT_EQ(accumulator.Convert(1, false), 1);
-  EXPECT_EQ(accumulator.Convert(1, false), 2);
+  EXPECT_EQ(accumulator.Convert(1, false), 1);
 }
 
 TEST(TrackpadScrollAccumulator, CarriesSubunitFramesPerAxis) {
-  TrackpadScrollAccumulator horizontal(1.2, 12000);
-  TrackpadScrollAccumulator vertical(1.2, 12000);
+  TrackpadScrollAccumulator horizontal(12000);
+  TrackpadScrollAccumulator vertical(12000);
 
-  for (int i = 0; i < 8; ++i) {
+  for (int i = 0; i < 9; ++i) {
     EXPECT_EQ(horizontal.Convert(0.1, false), 0);
   }
   EXPECT_EQ(horizontal.Convert(0.1, false), 1);
@@ -62,7 +62,7 @@ TEST(TrackpadScrollAccumulator, CarriesSubunitFramesPerAxis) {
   EXPECT_EQ(vertical.Convert(1, true), -1);
   EXPECT_EQ(vertical.Convert(1, true), -1);
   EXPECT_EQ(vertical.Convert(1, true), -1);
-  EXPECT_EQ(vertical.Convert(1, true), -2);
+  EXPECT_EQ(vertical.Convert(1, true), -1);
 }
 
 }  // namespace test

--- a/windows/test/hardware_simulator_plugin_test.cpp
+++ b/windows/test/hardware_simulator_plugin_test.cpp
@@ -9,6 +9,7 @@
 #include <variant>
 
 #include "hardware_simulator_plugin.h"
+#include "trackpad_scroll_accumulator.h"
 
 namespace hardware_simulator {
 namespace test {
@@ -37,6 +38,31 @@ TEST(HardwareSimulatorPlugin, GetPlatformVersion) {
   // Since the exact string varies by host, just ensure that it's a string
   // with the expected format.
   EXPECT_TRUE(result_string.rfind("Windows ", 0) == 0);
+}
+
+TEST(TrackpadScrollAccumulator, PreservesCumulativeBrowserPixelDistance) {
+  TrackpadScrollAccumulator accumulator(1.2, 12000);
+
+  EXPECT_EQ(accumulator.Convert(1, false), 1);
+  EXPECT_EQ(accumulator.Convert(1, false), 1);
+  EXPECT_EQ(accumulator.Convert(1, false), 1);
+  EXPECT_EQ(accumulator.Convert(1, false), 1);
+  EXPECT_EQ(accumulator.Convert(1, false), 2);
+}
+
+TEST(TrackpadScrollAccumulator, CarriesSubunitFramesPerAxis) {
+  TrackpadScrollAccumulator horizontal(1.2, 12000);
+  TrackpadScrollAccumulator vertical(1.2, 12000);
+
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(horizontal.Convert(0.1, false), 0);
+  }
+  EXPECT_EQ(horizontal.Convert(0.1, false), 1);
+  EXPECT_EQ(vertical.Convert(1, true), -1);
+  EXPECT_EQ(vertical.Convert(1, true), -1);
+  EXPECT_EQ(vertical.Convert(1, true), -1);
+  EXPECT_EQ(vertical.Convert(1, true), -1);
+  EXPECT_EQ(vertical.Convert(1, true), -2);
 }
 
 }  // namespace test

--- a/windows/trackpad_scroll_accumulator.h
+++ b/windows/trackpad_scroll_accumulator.h
@@ -1,0 +1,53 @@
+#ifndef FLUTTER_PLUGIN_TRACKPAD_SCROLL_ACCUMULATOR_H_
+#define FLUTTER_PLUGIN_TRACKPAD_SCROLL_ACCUMULATOR_H_
+
+#include <algorithm>
+#include <cmath>
+
+namespace hardware_simulator {
+
+// Converts continuous trackpad deltas to an integral legacy wheel API while
+// carrying the fractional remainder forward. This preserves cumulative
+// distance without rounding every frame away from zero.
+class TrackpadScrollAccumulator {
+public:
+  TrackpadScrollAccumulator(double output_units_per_input_unit,
+                            double max_output_distance)
+      : output_units_per_input_unit_(output_units_per_input_unit),
+        max_output_distance_(max_output_distance) {}
+
+  int Convert(double logical_distance, bool invert) {
+    if (!std::isfinite(logical_distance)) {
+      return 0;
+    }
+
+    const double direction = invert ? -1.0 : 1.0;
+    const double converted =
+        logical_distance * direction * output_units_per_input_unit_ + residual_;
+    const double clamped =
+        (std::clamp)(converted, -max_output_distance_, max_output_distance_);
+
+    // Keep truncation as the only integer conversion. The tiny tolerance only
+    // prevents exact rational totals such as 5 * 1.2 from landing immediately
+    // below an integer because of binary floating-point representation.
+    constexpr double kIntegerBoundaryTolerance = 1e-9;
+    const double adjusted =
+        clamped + std::copysign(kIntegerBoundaryTolerance, clamped);
+    const int whole_units = static_cast<int>(adjusted);
+
+    residual_ = clamped - whole_units;
+    if (std::abs(residual_) < kIntegerBoundaryTolerance) {
+      residual_ = 0;
+    }
+    return whole_units;
+  }
+
+ private:
+  double output_units_per_input_unit_;
+  double max_output_distance_;
+  double residual_ = 0;
+};
+
+} // namespace hardware_simulator
+
+#endif // FLUTTER_PLUGIN_TRACKPAD_SCROLL_ACCUMULATOR_H_

--- a/windows/trackpad_scroll_accumulator.h
+++ b/windows/trackpad_scroll_accumulator.h
@@ -11,10 +11,8 @@ namespace hardware_simulator {
 // distance without rounding every frame away from zero.
 class TrackpadScrollAccumulator {
 public:
-  TrackpadScrollAccumulator(double output_units_per_input_unit,
-                            double max_output_distance)
-      : output_units_per_input_unit_(output_units_per_input_unit),
-        max_output_distance_(max_output_distance) {}
+  explicit TrackpadScrollAccumulator(double max_output_distance)
+      : max_output_distance_(max_output_distance) {}
 
   int Convert(double logical_distance, bool invert) {
     if (!std::isfinite(logical_distance)) {
@@ -22,14 +20,13 @@ public:
     }
 
     const double direction = invert ? -1.0 : 1.0;
-    const double converted =
-        logical_distance * direction * output_units_per_input_unit_ + residual_;
+    const double converted = logical_distance * direction + residual_;
     const double clamped =
         (std::clamp)(converted, -max_output_distance_, max_output_distance_);
 
     // Keep truncation as the only integer conversion. The tiny tolerance only
-    // prevents exact rational totals such as 5 * 1.2 from landing immediately
-    // below an integer because of binary floating-point representation.
+    // prevents exact decimal totals from landing immediately below an integer
+    // because of binary floating-point representation.
     constexpr double kIntegerBoundaryTolerance = 1e-9;
     const double adjusted =
         clamped + std::copysign(kIntegerBoundaryTolerance, clamped);
@@ -43,7 +40,6 @@ public:
   }
 
  private:
-  double output_units_per_input_unit_;
   double max_output_distance_;
   double residual_ = 0;
 };


### PR DESCRIPTION
## What changed

- add a cross-platform `TrackpadScrollEvent` callback contract with Flutter-view position, canonical page-direction deltas, gesture phase, and momentum state
- start native capture for the first listener and stop it after the last listener is removed
- implement macOS capture from precise `NSEvent.scrollWheel` events without consuming the AppKit event
- add a unified precise-trackpad injection API that preserves fractional pixels where the platform supports it
- on macOS, rebuild continuous CoreGraphics events with 16.16 fixed-point deltas plus public scroll/momentum phase fields
- on Windows 10, replay unified trackpad input as ordinary high-resolution `WHEEL/HWHEEL` events and retain per-axis fractional remainders at the integer API boundary
- keep all magnitude scaling in Viewer Dart; Windows native applies no `×1.2`, `×1.5`, `×2`, mouse sensitivity multiplier, or `lround` on trackpad input
- keep Windows native limited to axis direction, safe clamping, fractional remainder carry and Win32 integer injection
- keep ordinary mouse-wheel magnitude unchanged and unsupported capture platforms as safe no-ops

## Why

Flutter macOS `PointerPanZoom` does not preserve the complete native momentum sequence. Reusing integer mouse-wheel injection also rounds native values such as `0.1` to zero on macOS. Native capture and precise macOS injection keep fractional pixels, direction conversion, and lifecycle metadata in the platform plugin. Windows 10 has no public precision-touchpad injector, so it replays Viewer-normalized values through ordinary wheel input without changing their cumulative magnitude.

## Validation

- plugin `flutter test --no-pub` (8 tests)
- Windows accumulator tests cover 1:1 integral distance and fractional remainder carry
- parent app 63 focused Viewer/normalizer tests
- parent app `flutter analyze --no-pub`
- parent app signed macOS release build with `CPP_LOG_AVAILABLE`
- verified against parent `cloudplayplus#442` commit `96dd510`