### PR TITLE
fix(macos): make Caps Lock toggle input sources repeatedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Inject macOS Caps Lock as explicit AlphaShift state changes so repeated
+  presses can switch input sources in both directions.
 * Define a cross-platform logical scroll contract and convert it at each
   native host boundary.
 * Move Windows scroll magnitude normalization to the Dart host layer; the

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -69,6 +69,43 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(hotSpot.y, 0)
   }
 
+  func testCapsLockDownTogglesAlphaShiftAndSanitizesInheritedFlags() throws {
+    let inheritedFlags: CGEventFlags = [
+      .maskShift,
+      .maskSecondaryFn,
+      .maskNumericPad,
+    ]
+
+    let enabledFlags = try XCTUnwrap(
+      HardwareSimulatorPlugin.capsLockFlagsForKeyEvent(
+        currentFlags: inheritedFlags,
+        isDown: true
+      )
+    )
+    XCTAssertTrue(enabledFlags.contains(.maskAlphaShift))
+    XCTAssertTrue(enabledFlags.contains(.maskShift))
+    XCTAssertFalse(enabledFlags.contains(.maskSecondaryFn))
+    XCTAssertFalse(enabledFlags.contains(.maskNumericPad))
+
+    let disabledFlags = try XCTUnwrap(
+      HardwareSimulatorPlugin.capsLockFlagsForKeyEvent(
+        currentFlags: enabledFlags,
+        isDown: true
+      )
+    )
+    XCTAssertFalse(disabledFlags.contains(.maskAlphaShift))
+    XCTAssertTrue(disabledFlags.contains(.maskShift))
+  }
+
+  func testCapsLockReleaseDoesNotCreateAnotherStateChange() {
+    let flags = HardwareSimulatorPlugin.capsLockFlagsForKeyEvent(
+      currentFlags: [.maskAlphaShift],
+      isDown: false
+    )
+
+    XCTAssertNil(flags)
+  }
+
   func testCursorEncodingPrefersImagePointSize() throws {
     let plugin = HardwareSimulatorPlugin()
     let bitmapRep = try XCTUnwrap(NSBitmapImageRep(

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1524,6 +1524,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       isDown: Bool,
       isRepeat: Bool
   ) {
+      if macKeyCode == 0x39 {
+          postCapsLockEvent(isDown: isDown)
+          return
+      }
+
       // Create and post the keyboard event.
       //
       // Strip the Fn (secondaryFn) and NumericPad flags before posting.
@@ -1549,6 +1554,47 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           )
       }
       event?.post(tap: .cghidEventTap)
+  }
+
+  static func capsLockFlagsForKeyEvent(
+      currentFlags: CGEventFlags,
+      isDown: Bool
+  ) -> CGEventFlags? {
+      // Caps Lock is a status key on macOS. Its release does not create a
+      // second state change; the next press flips AlphaShift back instead.
+      guard isDown else {
+          return nil
+      }
+
+      var flags = currentFlags
+      flags.remove([.maskSecondaryFn, .maskNumericPad])
+      if flags.contains(.maskAlphaShift) {
+          flags.remove(.maskAlphaShift)
+      } else {
+          flags.insert(.maskAlphaShift)
+      }
+      return flags
+  }
+
+  private func postCapsLockEvent(isDown: Bool) {
+      let currentFlags = CGEventSource.flagsState(.combinedSessionState)
+      guard let flags = Self.capsLockFlagsForKeyEvent(
+        currentFlags: currentFlags,
+        isDown: isDown
+      ) else {
+          return
+      }
+      let capsLockEnabled = flags.contains(.maskAlphaShift)
+      guard let event = CGEvent(
+        keyboardEventSource: nil,
+        virtualKey: 0x39,
+        keyDown: capsLockEnabled
+      ) else {
+          return
+      }
+      event.type = .flagsChanged
+      event.flags = flags
+      event.post(tap: .cghidEventTap)
   }
 
   private func systemKeyboardRepeatDelay() -> DispatchTimeInterval {


### PR DESCRIPTION
## Summary

- inject macOS Caps Lock as an explicit `flagsChanged` status transition
- toggle `maskAlphaShift` on each remote key-down and ignore key-up as a second state change
- preserve other active modifiers while removing inherited Fn/NumericPad pollution
- add macOS XCTest coverage for repeated toggles and release handling

## Root cause

Caps Lock is a macOS status key, but the host injected it as an ordinary `keyDown`/`keyUp` pair created from the shared session state. After the first transition, the inherited AlphaShift state could prevent the next press from producing the reverse edge, so Caps switched to ABC once but did not switch back.

## Verification

- `dart format --output=none --set-exit-if-changed lib test` (plugin): passed
- `flutter test` (plugin): 8 tests passed
- `flutter analyze` (plugin): completed with the existing example lint backlog; no new Dart diagnostics
- `dart format --output=none --set-exit-if-changed lib test` (CloudPlayPlus): passed, 331 files unchanged
- `flutter analyze` (CloudPlayPlus): no issues
- `flutter build windows --release` (CloudPlayPlus): passed
  - artifact: `build/windows/x64/runner/Release/cloudplayplus.exe`

## macOS validation

The macOS XCTest cases were added but cannot run on the Windows development host. Runtime verification should confirm this sequence on a Mac host with “Use Caps Lock to switch to and from ABC” enabled:

1. Chinese → press Caps Lock → ABC
2. press Caps Lock again → Chinese
3. repeat several times and verify Shift/Ctrl/Option/Command remain unaffected