### PR TITLE
fix(macos): preserve modifiers for injected shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Derive injected macOS keyboard flags from remote pressed modifiers so
+  back-to-back shortcuts keep their Command/Control state reliably.
 * Inject macOS Caps Lock as explicit AlphaShift state changes so repeated
   presses can switch input sources in both directions.
 * Define a cross-platform logical scroll contract and convert it at each

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -106,6 +106,36 @@ class RunnerTests: XCTestCase {
     XCTAssertNil(flags)
   }
 
+  func testInjectedKeyboardFlagsUseRemoteModifierState() {
+    let flags = HardwareSimulatorPlugin.keyboardFlagsForPressedKeyCodes(
+      [0x36, 0x38, 0x3B],
+      inheritedFlags: [
+        .maskAlphaShift,
+        .maskAlternate,
+        .maskSecondaryFn,
+        .maskNumericPad,
+      ]
+    )
+
+    XCTAssertTrue(flags.contains(.maskAlphaShift))
+    XCTAssertTrue(flags.contains(.maskCommand))
+    XCTAssertTrue(flags.contains(.maskShift))
+    XCTAssertTrue(flags.contains(.maskControl))
+    XCTAssertFalse(flags.contains(.maskAlternate))
+    XCTAssertFalse(flags.contains(.maskSecondaryFn))
+    XCTAssertFalse(flags.contains(.maskNumericPad))
+  }
+
+  func testInjectedKeyboardFlagsClearReleasedRemoteModifiers() {
+    let flags = HardwareSimulatorPlugin.keyboardFlagsForPressedKeyCodes(
+      [],
+      inheritedFlags: [.maskCommand, .maskControl]
+    )
+
+    XCTAssertFalse(flags.contains(.maskCommand))
+    XCTAssertFalse(flags.contains(.maskControl))
+  }
+
   func testCursorEncodingPrefersImagePointSize() throws {
     let plugin = HardwareSimulatorPlugin()
     let bitmapRep = try XCTUnwrap(NSBitmapImageRep(

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1477,7 +1477,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       
       // 特殊键 - 正确映射
       0x5B: 0x37, // Left Windows/Command
-      0x5C: 0x37, // Right Windows/Command
+      0x5C: 0x36, // Right Windows/Command
       0x5D: 0x6E, // Apps/Context Menu
       0x5F: 0x7F, // Sleep
       
@@ -1546,7 +1546,14 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         virtualKey: macKeyCode,
         keyDown: isDown
       )
-      event?.flags.remove([.maskSecondaryFn, .maskNumericPad])
+      let inheritedFlags = CGEventSource.flagsState(.combinedSessionState)
+      event?.flags = Self.keyboardFlagsForPressedKeyCodes(
+        Array(activeKeyMacCodes.values),
+        inheritedFlags: inheritedFlags
+      )
+      if Self.isModifierMacKeyCode(macKeyCode) {
+          event?.type = .flagsChanged
+      }
       if isDown {
           event?.setIntegerValueField(
             .keyboardEventAutorepeat,
@@ -1554,6 +1561,53 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           )
       }
       event?.post(tap: .cghidEventTap)
+  }
+
+  static func keyboardFlagsForPressedKeyCodes(
+      _ pressedKeyCodes: [CGKeyCode],
+      inheritedFlags: CGEventFlags
+  ) -> CGEventFlags {
+      var flags = inheritedFlags
+      // Modifier state for injected input must come from our own pressed-key
+      // table. Inheriting the host's physical modifiers makes a remote chord
+      // nondeterministic, while omitting these flags makes Command+A arrive as
+      // a plain A on macOS.
+      flags.remove([
+        .maskShift,
+        .maskControl,
+        .maskAlternate,
+        .maskCommand,
+        .maskSecondaryFn,
+        .maskNumericPad,
+      ])
+      for keyCode in pressedKeyCodes {
+          switch keyCode {
+          case 0x38, 0x3C:
+              flags.insert(.maskShift)
+          case 0x3B, 0x3E:
+              flags.insert(.maskControl)
+          case 0x3A, 0x3D:
+              flags.insert(.maskAlternate)
+          case 0x36, 0x37:
+              flags.insert(.maskCommand)
+          default:
+              break
+          }
+      }
+      return flags
+  }
+
+  static func isModifierMacKeyCode(_ keyCode: CGKeyCode) -> Bool {
+      switch keyCode {
+      case 0x36, 0x37, // Command
+           0x38, 0x3C, // Shift
+           0x39,       // Caps Lock
+           0x3A, 0x3D, // Option
+           0x3B, 0x3E: // Control
+          return true
+      default:
+          return false
+      }
   }
 
   static func capsLockFlagsForKeyEvent(

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -1551,9 +1551,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         Array(activeKeyMacCodes.values),
         inheritedFlags: inheritedFlags
       )
-      if Self.isModifierMacKeyCode(macKeyCode) {
-          event?.type = .flagsChanged
-      }
+      // Keep Shift/Control/Option/Command as ordinary keyDown/keyUp events.
+      // Recasting them as flagsChanged can leave the combined session modifier
+      // state latched after key-up (for example, after remote Ctrl+Tab).
       if isDown {
           event?.setIntegerValueField(
             .keyboardEventAutorepeat,
@@ -1595,19 +1595,6 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           }
       }
       return flags
-  }
-
-  static func isModifierMacKeyCode(_ keyCode: CGKeyCode) -> Bool {
-      switch keyCode {
-      case 0x36, 0x37, // Command
-           0x38, 0x3C, // Shift
-           0x39,       // Caps Lock
-           0x3A, 0x3D, // Option
-           0x3B, 0x3E: // Control
-          return true
-      default:
-          return false
-      }
   }
 
   static func capsLockFlagsForKeyEvent(


### PR DESCRIPTION
## Summary

- derive injected macOS keyboard flags from the remote pressed-key table so back-to-back Command/Control shortcuts retain their modifier state
- keep ordinary modifier `keyDown`/`keyUp` event types so Control is reliably released after chords such as Ctrl+Tab
- map right Windows to right Command
- add XCTest coverage for active and released remote modifier flags

## Testing

- `flutter test test/hardware_simulator_method_channel_test.dart`
- `flutter analyze` (no errors or warnings; exits nonzero because the existing example app reports 269 info-level lints)
- macOS XCTest not run locally (Windows development host)