### PR TITLE
feat(windows): detect editable text after remote clicks

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'fps_game_example.dart';
 import 'display_manager_page.dart';
 import 'immersive_mode_example.dart';
+import 'windows_editing_events_example.dart';
 
 void main() {
   //SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
@@ -379,6 +380,22 @@ class _SimulatorScreenState extends State<SimulatorScreen> {
               padding: EdgeInsets.symmetric(horizontal: 32, vertical: 16),
               textStyle: TextStyle(fontSize: 18),
             ),
+          ),
+        if (Platform.isWindows)
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const WindowsEditingEventsExample(),
+                ),
+              );
+            },
+            style: ElevatedButton.styleFrom(
+              padding: EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+              textStyle: TextStyle(fontSize: 18),
+            ),
+            child: const Text('Windows 键盘弹出决策'),
           ),
         SizedBox(height: 20),
         // First Row: Absolute Mouse Move

--- a/example/lib/windows_editing_events_example.dart
+++ b/example/lib/windows_editing_events_example.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import 'package:hardware_simulator/hardware_simulator.dart';
+
+class WindowsEditingEventsExample extends StatefulWidget {
+  const WindowsEditingEventsExample({super.key});
+
+  @override
+  State<WindowsEditingEventsExample> createState() =>
+      _WindowsEditingEventsExampleState();
+}
+
+class _WindowsEditingEventsExampleState
+    extends State<WindowsEditingEventsExample> {
+  final HWMouse _testMouse = HWMouse();
+  bool _listening = false;
+  bool _injectingTestClick = false;
+  bool? _showKeyboard;
+  WindowsTextInputDecision? _lastDecision;
+  int _inspectionCount = 0;
+  int _decisionChangeCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _startListening();
+  }
+
+  @override
+  void dispose() {
+    if (_listening) {
+      HardwareSimulator.removeWindowsTextInputDecision(_onDecision);
+    }
+    super.dispose();
+  }
+
+  void _startListening() {
+    if (_listening) return;
+    HardwareSimulator.addWindowsTextInputDecision(_onDecision);
+    setState(() => _listening = true);
+  }
+
+  void _stopListening() {
+    if (!_listening) return;
+    HardwareSimulator.removeWindowsTextInputDecision(_onDecision);
+    setState(() => _listening = false);
+  }
+
+  void _resetDecision() {
+    setState(() {
+      _showKeyboard = null;
+      _lastDecision = null;
+      _inspectionCount = 0;
+      _decisionChangeCount = 0;
+    });
+  }
+
+  void _onDecision(WindowsTextInputDecision decision) {
+    if (!mounted) return;
+    setState(() {
+      _inspectionCount++;
+      if (_showKeyboard != decision.active) {
+        _decisionChangeCount++;
+      }
+      _showKeyboard = decision.active;
+      _lastDecision = decision;
+    });
+  }
+
+  Future<void> _injectTestClick() async {
+    if (_injectingTestClick) return;
+    setState(() => _injectingTestClick = true);
+    try {
+      await Future<void>.delayed(const Duration(seconds: 3));
+      if (!mounted || !_listening) return;
+      _testMouse.performMouseClick(1, true);
+      _testMouse.performMouseClick(1, false);
+    } finally {
+      if (mounted) {
+        setState(() => _injectingTestClick = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Windows 键盘弹出决策')),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '这里不监听全局焦点或鼠标事件。仅在插件注入远端左键抬起后，'
+              '原生线程等待 80ms，再做一次 UI Automation 检查；页面只展示'
+              '最终的弹出或收起结论。可启动 3 秒测试点击，再把鼠标移到其它'
+              '应用的文本框或非文本区域。',
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                FilledButton.icon(
+                  onPressed: _listening ? null : _startListening,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('开始检查'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _listening ? _stopListening : null,
+                  icon: const Icon(Icons.stop),
+                  label: const Text('停止检查'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _listening && !_injectingTestClick
+                      ? _injectTestClick
+                      : null,
+                  icon: const Icon(Icons.ads_click),
+                  label: Text(
+                    _injectingTestClick ? '请把鼠标移到目标控件…' : '3 秒后模拟远端点击',
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: _resetDecision,
+                  icon: const Icon(Icons.restart_alt),
+                  label: const Text('重置判断'),
+                ),
+                Chip(
+                  avatar: Icon(
+                    _listening ? Icons.sensors : Icons.sensors_off,
+                    size: 18,
+                  ),
+                  label: Text(_listening ? '按需检查已启用' : '检查已停止'),
+                ),
+                Text('$_inspectionCount 次检查 · $_decisionChangeCount 次决策变化'),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Expanded(
+              child: _DecisionPanel(
+                showKeyboard: _showKeyboard,
+                decision: _lastDecision,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DecisionPanel extends StatelessWidget {
+  const _DecisionPanel({
+    required this.showKeyboard,
+    required this.decision,
+  });
+
+  final bool? showKeyboard;
+  final WindowsTextInputDecision? decision;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final color = switch (showKeyboard) {
+      true => Colors.green,
+      false => scheme.outline,
+      null => scheme.primary,
+    };
+    final icon = switch (showKeyboard) {
+      true => Icons.keyboard_alt,
+      false => Icons.keyboard_hide,
+      null => Icons.touch_app,
+    };
+    final title = switch (showKeyboard) {
+      true => '弹出原生键盘',
+      false => '收起原生键盘',
+      null => '等待远端点击',
+    };
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 180),
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        border: Border.all(color: color, width: 2),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Center(
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 88, color: color),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                decision == null
+                    ? '点击远端应用中的文本框或非文本区域进行验证'
+                    : _description(decision!),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              if (decision?.active == true) ...[
+                const SizedBox(height: 20),
+                Chip(
+                  avatar: Icon(
+                    decision!.secure == true
+                        ? Icons.password
+                        : Icons.text_fields,
+                    size: 18,
+                  ),
+                  label: Text(_secureLabel(decision!.secure)),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _description(WindowsTextInputDecision decision) {
+    return switch ((decision.active, decision.secure)) {
+      (true, true) => '检测到密码输入控件；不读取任何文本内容',
+      (true, false) => '检测到普通可编辑文本控件',
+      (true, null) => '检测到可编辑文本控件；密码状态未知',
+      (false, _) => '未检测到可编辑文本控件',
+    };
+  }
+
+  static String _secureLabel(bool? secure) {
+    return switch (secure) {
+      true => '密码输入',
+      false => '普通文本输入',
+      null => '密码状态未知',
+    };
+  }
+}

--- a/example/test/windows_editing_events_example_test.dart
+++ b/example/test/windows_editing_events_example_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hardware_simulator_example/windows_editing_events_example.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('hardware_simulator');
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async => true);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  testWidgets('直接展示原生检查给出的键盘弹出或收起结论', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: WindowsEditingEventsExample()),
+    );
+    await tester.pump();
+    expect(find.text('等待远端点击'), findsOneWidget);
+
+    await _sendDecision(
+      const <String, dynamic>{
+        'active': true,
+        'secure': false,
+      },
+    );
+    await tester.pump();
+    expect(find.text('弹出原生键盘'), findsOneWidget);
+    expect(find.text('检测到普通可编辑文本控件'), findsOneWidget);
+    expect(find.text('普通文本输入'), findsOneWidget);
+
+    await _sendDecision(
+      const <String, dynamic>{
+        'active': false,
+        'secure': null,
+      },
+    );
+    await tester.pump();
+    expect(find.text('收起原生键盘'), findsOneWidget);
+    expect(find.text('未检测到可编辑文本控件'), findsOneWidget);
+    expect(find.text('2 次检查 · 2 次决策变化'), findsOneWidget);
+  });
+}
+
+Future<void> _sendDecision(Map<String, dynamic> decision) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+    'hardware_simulator',
+    const StandardMethodCodec().encodeMethodCall(
+      MethodCall('onWindowsTextInputDecision', decision),
+    ),
+    null,
+  );
+}

--- a/example/windows/CMakeLists.txt
+++ b/example/windows/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.14)
 project(hardware_simulator_example LANGUAGES CXX)
 
+# Enable the plugin's native tests before adding any subdirectories so CTest
+# can discover them from the top-level Windows build directory.
+set(include_hardware_simulator_tests TRUE)
+enable_testing()
+
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
 set(BINARY_NAME "hardware_simulator_example")
@@ -51,9 +56,6 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 
 # Application build; see runner/CMakeLists.txt.
 add_subdirectory("runner")
-
-# Enable the test target.
-set(include_hardware_simulator_tests TRUE)
 
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -4,7 +4,9 @@ export 'hardware_simulator_platform_interface.dart'
         DisplayCountChangedCallback,
         TrackpadScrollCallback,
         TrackpadScrollEvent,
-        TrackpadScrollPhase;
+        TrackpadScrollPhase,
+        WindowsTextInputDecision,
+        WindowsTextInputDecisionCallback;
 import 'display_data.dart';
 
 /// Snapshot of the macOS TCC permissions relevant to remote-control hosting.
@@ -257,6 +259,19 @@ class HardwareSimulator {
 
   static void removeTrackpadScroll(TrackpadScrollCallback callback) {
     HardwareSimulatorPlatform.instance.removeTrackpadScroll(callback);
+  }
+
+  /// 注册 Windows 远端点击后的软件盘决策。
+  static void addWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    HardwareSimulatorPlatform.instance.addWindowsTextInputDecision(callback);
+  }
+
+  static void removeWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    HardwareSimulatorPlatform.instance.removeWindowsTextInputDecision(callback);
   }
 
   // ignore: constant_identifier_names

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -51,6 +51,16 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
             callback(event);
           }
         }
+      } else if (call.method == "onWindowsTextInputDecision") {
+        final arguments = call.arguments;
+        if (arguments is Map) {
+          final decision = WindowsTextInputDecision.fromMap(arguments);
+          for (final callback in List<WindowsTextInputDecisionCallback>.of(
+            windowsTextInputDecisionCallbacks,
+          )) {
+            callback(decision);
+          }
+        }
       } else if (call.method == "onCursorImageMessage") {
         int callbackID = call.arguments['callbackID'];
         if (cursorImageCallbacks.containsKey(callbackID)) {
@@ -296,6 +306,51 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   Future<void> stopTrackpadScrollCapture() async {
     try {
       await methodChannel.invokeMethod<void>('stopTrackpadScrollCapture');
+    } on MissingPluginException {
+      return;
+    }
+  }
+
+  final List<WindowsTextInputDecisionCallback>
+      windowsTextInputDecisionCallbacks = [];
+
+  @override
+  void addWindowsTextInputDecision(WindowsTextInputDecisionCallback callback) {
+    if (!isinitialized) init();
+    if (windowsTextInputDecisionCallbacks.contains(callback)) return;
+    final shouldStartCapture = windowsTextInputDecisionCallbacks.isEmpty;
+    windowsTextInputDecisionCallbacks.add(callback);
+    if (shouldStartCapture) {
+      unawaited(startWindowsTextInputDecisionCapture());
+    }
+  }
+
+  @override
+  void removeWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    final removed = windowsTextInputDecisionCallbacks.remove(callback);
+    if (removed && windowsTextInputDecisionCallbacks.isEmpty) {
+      unawaited(stopWindowsTextInputDecisionCapture());
+    }
+  }
+
+  @override
+  Future<bool> startWindowsTextInputDecisionCapture() async {
+    try {
+      final supported = await methodChannel
+          .invokeMethod<Object?>('startWindowsTextInputDecisionCapture');
+      return supported == true;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  @override
+  Future<void> stopWindowsTextInputDecisionCapture() async {
+    try {
+      await methodChannel
+          .invokeMethod<void>('stopWindowsTextInputDecisionCapture');
     } on MissingPluginException {
       return;
     }

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -12,6 +12,9 @@ typedef KeyboardPressedCallback = void Function(int button, bool isDown);
 typedef KeyBlockedCallback = void Function(int keyCode, bool isDown);
 typedef CursorWheelCallback = void Function(double deltaX, double deltaY);
 typedef TrackpadScrollCallback = void Function(TrackpadScrollEvent event);
+typedef WindowsTextInputDecisionCallback = void Function(
+  WindowsTextInputDecision decision,
+);
 typedef CursorImageUpdatedCallback = void Function(
     int message, int messageInfo, Uint8List cursorImage);
 typedef CursorPositionUpdatedCallback = void Function(
@@ -53,6 +56,31 @@ class TrackpadScrollEvent {
   final double deltaY;
   final TrackpadScrollPhase phase;
   final bool isMomentum;
+}
+
+/// 远端左键抬起后，Windows UI Automation 给出的软件盘决策。
+///
+/// [active] 为 true 时应弹出软件盘，否则应收起。[secure] 只在 UIA 明确判断
+/// 当前可编辑控件是否为密码框时取 true 或 false；无法确认或 [active] 为 false
+/// 时为 null。
+@immutable
+class WindowsTextInputDecision {
+  const WindowsTextInputDecision({
+    required this.active,
+    required this.secure,
+  });
+
+  factory WindowsTextInputDecision.fromMap(Map<Object?, Object?> map) {
+    final active = map['active'] == true;
+    final secure = map['secure'];
+    return WindowsTextInputDecision(
+      active: active,
+      secure: active && secure is bool ? secure : null,
+    );
+  }
+
+  final bool active;
+  final bool? secure;
 }
 
 abstract class HardwareSimulatorPlatform extends PlatformInterface {
@@ -205,6 +233,24 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
 
   /// Stops native precision trackpad capture when implemented.
   Future<void> stopTrackpadScrollCapture() async {}
+
+  /// 注册 Windows 远端点击后的文本输入决策。
+  void addWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {}
+
+  /// 移除 Windows 软件盘决策监听器。
+  void removeWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {}
+
+  /// 启动 Windows 按需 UI Automation 检查；不支持的平台返回 false。
+  Future<bool> startWindowsTextInputDecisionCapture() async {
+    return false;
+  }
+
+  /// 停止 Windows 按需 UI Automation 检查。
+  Future<void> stopWindowsTextInputDecisionCapture() async {}
 
   void addCursorImageUpdated(
       CursorImageUpdatedCallback callback, int callbackId, bool hookAll) {

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -204,4 +204,81 @@ void main() {
     expect(received!.isMomentum, isTrue);
     await Future<void>.delayed(Duration.zero);
   });
+
+  test('first and last Windows text input listeners manage native capture',
+      () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        return methodCall.method == 'startWindowsTextInputDecisionCapture';
+      },
+    );
+
+    void firstListener(WindowsTextInputDecision _) {}
+    void secondListener(WindowsTextInputDecision _) {}
+    platform.addWindowsTextInputDecision(firstListener);
+    platform.addWindowsTextInputDecision(firstListener);
+    platform.addWindowsTextInputDecision(secondListener);
+    await Future<void>.delayed(Duration.zero);
+
+    platform.removeWindowsTextInputDecision(firstListener);
+    await Future<void>.delayed(Duration.zero);
+    expect(
+      calls.map((call) => call.method),
+      ['startWindowsTextInputDecisionCapture'],
+    );
+
+    platform.removeWindowsTextInputDecision(secondListener);
+    await Future<void>.delayed(Duration.zero);
+    expect(
+      calls.map((call) => call.method),
+      [
+        'startWindowsTextInputDecisionCapture',
+        'stopWindowsTextInputDecisionCapture',
+      ],
+    );
+  });
+
+  test('decodes minimal Windows text input decisions', () async {
+    WindowsTextInputDecision? received;
+    late WindowsTextInputDecisionCallback listener;
+    listener = (decision) {
+      received = decision;
+      platform.removeWindowsTextInputDecision(listener);
+    };
+    platform.addWindowsTextInputDecision(listener);
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      'hardware_simulator',
+      const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('onWindowsTextInputDecision', <String, dynamic>{
+          'active': true,
+          'secure': false,
+        }),
+      ),
+      null,
+    );
+
+    expect(received, isNotNull);
+    expect(received!.active, isTrue);
+    expect(received!.secure, isFalse);
+    await Future<void>.delayed(Duration.zero);
+  });
+
+  test('normalizes unknown and inactive secure state to null', () {
+    expect(
+      WindowsTextInputDecision.fromMap(const {'active': true}).secure,
+      isNull,
+    );
+    expect(
+      WindowsTextInputDecision.fromMap(
+        const {'active': false, 'secure': true},
+      ).secure,
+      isNull,
+    );
+  });
 }

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -30,6 +30,8 @@ list(APPEND PLUGIN_SOURCES
   "notification_window.cc"
   "notification_window.h"
   "trackpad_scroll_accumulator.h"
+  "windows_editing_event_monitor.cc"
+  "windows_editing_event_monitor.h"
   "virtual_display.cc"
   "virtual_display.h"
   "virtual_display_control.cc"
@@ -81,6 +83,9 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin
   setupapi
   cfgmgr32
   user32
+  ole32
+  oleaut32
+  uiautomationcore
   wtsapi32)
 
 # List of absolute paths to libraries that should be bundled with the plugin.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -112,3 +112,61 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   # Link necessary libraries for the example
   target_link_libraries(virtual_display_example PRIVATE)
 endif()
+
+# Build native unit tests only for the example application, which opts in via
+# include_hardware_simulator_tests. Plugin consumers do not fetch or build
+# Google Test.
+if(include_${PROJECT_NAME}_tests)
+  set(TEST_RUNNER "${PROJECT_NAME}_test")
+  enable_testing()
+
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/release-1.11.0.zip
+  )
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  set(INSTALL_GTEST OFF CACHE BOOL "Disable installation of googletest" FORCE)
+  FetchContent_MakeAvailable(googletest)
+
+  add_executable(${TEST_RUNNER}
+    "test/hardware_simulator_plugin_test.cpp"
+    ${PLUGIN_SOURCES}
+  )
+  apply_standard_settings(${TEST_RUNNER})
+  target_compile_options(${TEST_RUNNER} PRIVATE
+    /wd"4245" /wd"4505" /wd"4828" /utf-8)
+  target_include_directories(${TEST_RUNNER} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/vigembus/include"
+  )
+  if(TARGET cpp_log_plugin)
+    target_compile_definitions(${TEST_RUNNER} PRIVATE CPP_LOG_AVAILABLE=1)
+    target_link_libraries(${TEST_RUNNER} PRIVATE cpp_log_plugin)
+  endif()
+  target_link_libraries(${TEST_RUNNER} PRIVATE
+    flutter
+    flutter_wrapper_plugin
+    "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/vigembus/lib/x64/ViGEmClient.lib"
+    setupapi
+    cfgmgr32
+    user32
+    ole32
+    oleaut32
+    uiautomationcore
+    wtsapi32
+    gtest_main
+    gmock
+  )
+  add_custom_command(TARGET ${TEST_RUNNER} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${FLUTTER_LIBRARY}"
+      "$<TARGET_FILE_DIR:${TEST_RUNNER}>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/vigembus/lib/x64/ViGEmClient.dll"
+      "$<TARGET_FILE_DIR:${TEST_RUNNER}>"
+  )
+
+  include(GoogleTest)
+  gtest_discover_tests(${TEST_RUNNER})
+endif()

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -169,4 +169,15 @@ if(include_${PROJECT_NAME}_tests)
 
   include(GoogleTest)
   gtest_discover_tests(${TEST_RUNNER})
+
+  # The example opts into tests as part of its normal build. Run the registered
+  # cases as well as compiling them so assertion failures fail validation.
+  add_custom_target(${TEST_RUNNER}_run ALL
+    COMMAND ${CMAKE_CTEST_COMMAND}
+      --test-dir "${CMAKE_BINARY_DIR}"
+      --build-config "$<CONFIG>"
+      --output-on-failure
+    DEPENDS ${TEST_RUNNER}
+    USES_TERMINAL
+  )
 endif()

--- a/windows/cpp_log_shim.h
+++ b/windows/cpp_log_shim.h
@@ -4,44 +4,12 @@
 #if defined(CPP_LOG_AVAILABLE)
 #include <cpp_log/cpp_log.h>
 #else
-#include <cstdarg>
-#include <cstdio>
-
-namespace hardware_simulator {
-namespace logging {
-
-inline void FallbackLog(const char* level, const char* tag,
-                        const char* format, ...) {
-  char message[2048] = {};
-  va_list args;
-  va_start(args, format);
-  std::vsnprintf(message, sizeof(message), format, args);
-  va_end(args);
-  std::fprintf(stderr, "[%s] [%s] %s\n", level,
-               tag && *tag ? tag : "NATIVE", message);
-}
-
-}  // namespace logging
-}  // namespace hardware_simulator
-
-#define CPPLOG_TRACE(tag, ...)                                      \
-  ::hardware_simulator::logging::FallbackLog("TRACE", (tag),        \
-                                              __VA_ARGS__)
-#define CPPLOG_DEBUG(tag, ...)                                      \
-  ::hardware_simulator::logging::FallbackLog("DEBUG", (tag),        \
-                                              __VA_ARGS__)
-#define CPPLOG_INFO(tag, ...)                                      \
-  ::hardware_simulator::logging::FallbackLog("INFO", (tag),        \
-                                              __VA_ARGS__)
-#define CPPLOG_WARN(tag, ...)                                      \
-  ::hardware_simulator::logging::FallbackLog("WARN", (tag),        \
-                                              __VA_ARGS__)
-#define CPPLOG_ERROR(tag, ...)                                     \
-  ::hardware_simulator::logging::FallbackLog("ERROR", (tag),       \
-                                              __VA_ARGS__)
-#define CPPLOG_CRITICAL(tag, ...)                                  \
-  ::hardware_simulator::logging::FallbackLog("CRITICAL", (tag),    \
-                                              __VA_ARGS__)
+#define CPPLOG_TRACE(tag, ...) ((void)0)
+#define CPPLOG_DEBUG(tag, ...) ((void)0)
+#define CPPLOG_INFO(tag, ...) ((void)0)
+#define CPPLOG_WARN(tag, ...) ((void)0)
+#define CPPLOG_ERROR(tag, ...) ((void)0)
+#define CPPLOG_CRITICAL(tag, ...) ((void)0)
 #endif
 
 #endif  // HARDWARE_SIMULATOR_WINDOWS_CPP_LOG_SHIM_H_

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -6,6 +6,7 @@
 #include "notification_window.h"
 #include "trackpad_scroll_accumulator.h"
 #include "virtual_display_control.h"
+#include "windows_editing_event_monitor.h"
 #include "SmartKeyboardBlocker.h"
 
 // This must be included before many other Windows headers.
@@ -52,6 +53,8 @@ constexpr ULONG_PTR kCursorReseedExtraInfo =
     static_cast<ULONG_PTR>(0x43505052);  // "CPPR"
 constexpr UINT_PTR kCursorReseedSubclassId =
     static_cast<UINT_PTR>(0x43505052);
+constexpr wchar_t kWindowsTextInputDecisionMessageName[] =
+    L"CloudPlayPlus.HardwareSimulator.WindowsTextInputDecision";
 // Dart normalizes platform-specific scroll magnitudes. The native adapter only
 // converts the logical page direction and clamps it to a safe Win32 range.
 constexpr double kMaxWindowsWheelDistance =
@@ -1032,6 +1035,7 @@ HardwareSimulatorPlugin::HardwareSimulatorPlugin() {
 }
 
 HardwareSimulatorPlugin::~HardwareSimulatorPlugin() {
+    StopWindowsEditingEventMonitor();
     if (flutter_view_window_ != nullptr) {
         RemoveWindowSubclass(
             flutter_view_window_,
@@ -1048,6 +1052,116 @@ HardwareSimulatorPlugin::~HardwareSimulatorPlugin() {
         registrar_->UnregisterTopLevelWindowProcDelegate(dpi_monitor_proc_id_.value());
         dpi_monitor_proc_id_.reset();
     }
+}
+
+bool HardwareSimulatorPlugin::StartWindowsEditingEventMonitor() {
+  if (windows_editing_event_monitor_ &&
+      windows_editing_event_monitor_->is_running()) {
+    return true;
+  }
+  if (windows_editing_event_monitor_ || windows_editing_proc_id_.has_value()) {
+    StopWindowsEditingEventMonitor();
+  }
+  if (registrar_ == nullptr) {
+    return false;
+  }
+
+  windows_editing_window_ = FindFlutterWindow();
+  windows_editing_message_id_ =
+      RegisterWindowMessageW(kWindowsTextInputDecisionMessageName);
+  if (windows_editing_window_ == nullptr || windows_editing_message_id_ == 0) {
+    StopWindowsEditingEventMonitor();
+    return false;
+  }
+
+  windows_editing_proc_id_ = registrar_->RegisterTopLevelWindowProcDelegate(
+      [this](HWND, UINT message, WPARAM wparam,
+             LPARAM) -> std::optional<LRESULT> {
+        if (message != windows_editing_message_id_ ||
+            wparam != reinterpret_cast<WPARAM>(this)) {
+          return std::nullopt;
+        }
+
+        std::unique_ptr<WindowsTextInputDecision> decision;
+        {
+          std::lock_guard<std::mutex> lock(windows_editing_event_mutex_);
+          decision = std::move(pending_windows_text_input_decision_);
+          windows_editing_message_posted_ = false;
+        }
+        if (decision) {
+          SendWindowsTextInputDecision(*decision);
+        }
+        return 0;
+      });
+
+  windows_editing_event_monitor_ =
+      std::make_unique<WindowsEditingEventMonitor>(
+          [this](const WindowsTextInputDecision& decision) {
+            QueueWindowsTextInputDecision(decision);
+          });
+  if (!windows_editing_event_monitor_->Start()) {
+    StopWindowsEditingEventMonitor();
+    return false;
+  }
+  return true;
+}
+
+void HardwareSimulatorPlugin::StopWindowsEditingEventMonitor() {
+  windows_editing_event_monitor_.reset();
+
+  {
+    std::lock_guard<std::mutex> lock(windows_editing_event_mutex_);
+    pending_windows_text_input_decision_.reset();
+    windows_editing_message_posted_ = false;
+  }
+  if (windows_editing_window_ != nullptr &&
+      windows_editing_message_id_ != 0) {
+    MSG message = {};
+    while (PeekMessageW(&message, windows_editing_window_,
+                        windows_editing_message_id_,
+                        windows_editing_message_id_, PM_REMOVE)) {
+    }
+  }
+  if (registrar_ != nullptr && windows_editing_proc_id_.has_value()) {
+    registrar_->UnregisterTopLevelWindowProcDelegate(
+        windows_editing_proc_id_.value());
+  }
+  windows_editing_proc_id_.reset();
+  windows_editing_window_ = nullptr;
+  windows_editing_message_id_ = 0;
+}
+
+void HardwareSimulatorPlugin::QueueWindowsTextInputDecision(
+    const WindowsTextInputDecision& decision) {
+  std::lock_guard<std::mutex> lock(windows_editing_event_mutex_);
+  pending_windows_text_input_decision_ =
+      std::make_unique<WindowsTextInputDecision>(decision);
+  if (windows_editing_message_posted_) {
+    return;
+  }
+  windows_editing_message_posted_ = true;
+  if (!PostMessageW(windows_editing_window_, windows_editing_message_id_,
+                    reinterpret_cast<WPARAM>(this), 0)) {
+    pending_windows_text_input_decision_.reset();
+    windows_editing_message_posted_ = false;
+  }
+}
+
+void HardwareSimulatorPlugin::SendWindowsTextInputDecision(
+    const WindowsTextInputDecision& decision) {
+  if (!channel_) {
+    return;
+  }
+  flutter::EncodableMap message;
+  message[flutter::EncodableValue("active")] =
+      flutter::EncodableValue(decision.active);
+  message[flutter::EncodableValue("secure")] =
+      decision.secure.has_value()
+          ? flutter::EncodableValue(decision.secure.value())
+          : flutter::EncodableValue();
+  channel_->InvokeMethod(
+      "onWindowsTextInputDecision",
+      std::make_unique<flutter::EncodableValue>(message));
 }
 
 void async_send_input_retry(INPUT& i) {
@@ -1441,6 +1555,14 @@ void HardwareSimulatorPlugin::HandleMethodCall(
       version_stream << "7";
     }
     result->Success(flutter::EncodableValue(version_stream.str()));
+  } else if (method_call.method_name().compare(
+                 "startWindowsTextInputDecisionCapture") == 0) {
+    result->Success(
+        flutter::EncodableValue(StartWindowsEditingEventMonitor()));
+  } else if (method_call.method_name().compare(
+                 "stopWindowsTextInputDecisionCapture") == 0) {
+    StopWindowsEditingEventMonitor();
+    result->Success(nullptr);
   } else if (method_call.method_name().compare("setDesktopServiceAvailable") == 0) {
     bool available = false;
     if (args) {
@@ -1480,7 +1602,12 @@ void HardwareSimulatorPlugin::HandleMethodCall(
   } else if (method_call.method_name().compare("mousePress") == 0) {
         auto buttonid = (args->find(flutter::EncodableValue("buttonId")))->second;
         auto isDown = (args->find(flutter::EncodableValue("isDown")))->second;
-        performMouseButton(static_cast<int>(std::get<int>((buttonid))), !static_cast<bool>(std::get<bool>((isDown))));
+        const int button = static_cast<int>(std::get<int>(buttonid));
+        const bool is_down = static_cast<bool>(std::get<bool>(isDown));
+        performMouseButton(button, !is_down);
+        if (button == 1 && !is_down && windows_editing_event_monitor_) {
+          windows_editing_event_monitor_->InspectAfterRemoteClick();
+        }
         result->Success(nullptr);
   } else if (method_call.method_name().compare("mouseScroll") == 0) {
         auto dx = (args->find(flutter::EncodableValue("dx")))->second;

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -279,7 +279,7 @@ HDESK syncThreadDesktop() {
     return hDesk;
 }
 
-std::optional<int> HardwareSimulatorPlugin::dpi_monitor_proc_id_ = NULL;
+std::optional<int> HardwareSimulatorPlugin::dpi_monitor_proc_id_ = std::nullopt;
 std::vector<MonitorInfo> HardwareSimulatorPlugin::static_monitors_;
 std::map<int, std::function<void(int)>> HardwareSimulatorPlugin::display_count_callbacks_;
 std::mutex HardwareSimulatorPlugin::display_count_callbacks_mutex_;

--- a/windows/hardware_simulator_plugin.h
+++ b/windows/hardware_simulator_plugin.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <windows.h>
 #include <vector>
@@ -20,6 +21,9 @@ struct MonitorInfo {
 };
 
 namespace hardware_simulator {
+
+class WindowsEditingEventMonitor;
+struct WindowsTextInputDecision;
 
 class HardwareSimulatorPlugin : public flutter::Plugin {
  public:
@@ -64,6 +68,14 @@ class HardwareSimulatorPlugin : public flutter::Plugin {
  private:
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
   std::unique_ptr<std::thread> monitor_thread_;
+  std::unique_ptr<WindowsEditingEventMonitor> windows_editing_event_monitor_;
+  std::mutex windows_editing_event_mutex_;
+  std::unique_ptr<WindowsTextInputDecision>
+      pending_windows_text_input_decision_;
+  bool windows_editing_message_posted_ = false;
+  HWND windows_editing_window_ = nullptr;
+  UINT windows_editing_message_id_ = 0;
+  std::optional<int> windows_editing_proc_id_;
   bool immersive_mode_enabled_ = false;
   
   // Cursor lock related members
@@ -89,6 +101,12 @@ class HardwareSimulatorPlugin : public flutter::Plugin {
   
   // Helper methods for cursor lock
   void CleanupCursorLock();
+  bool StartWindowsEditingEventMonitor();
+  void StopWindowsEditingEventMonitor();
+  void QueueWindowsTextInputDecision(
+      const WindowsTextInputDecision& decision);
+  void SendWindowsTextInputDecision(
+      const WindowsTextInputDecision& decision);
   HWND FindFlutterWindow();
   bool SubscribeToRawInputData();
   void UnsubscribeFromRawInputData();

--- a/windows/test/hardware_simulator_plugin_test.cpp
+++ b/windows/test/hardware_simulator_plugin_test.cpp
@@ -1,8 +1,9 @@
+#include <windows.h>
+#include <UIAutomation.h>
 #include <flutter/method_call.h>
 #include <flutter/method_result_functions.h>
 #include <flutter/standard_method_codec.h>
 #include <gtest/gtest.h>
-#include <windows.h>
 
 #include <memory>
 #include <string>
@@ -10,6 +11,7 @@
 
 #include "hardware_simulator_plugin.h"
 #include "trackpad_scroll_accumulator.h"
+#include "windows_editing_event_monitor.h"
 
 namespace hardware_simulator {
 namespace test {
@@ -63,6 +65,30 @@ TEST(TrackpadScrollAccumulator, CarriesSubunitFramesPerAxis) {
   EXPECT_EQ(vertical.Convert(1, true), -1);
   EXPECT_EQ(vertical.Convert(1, true), -1);
   EXPECT_EQ(vertical.Convert(1, true), -1);
+}
+
+TEST(WindowsEditingEventMonitor, ClassifiesEditableControls) {
+  EXPECT_TRUE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_EditControlTypeId, false, true, false, false, false, false}));
+  EXPECT_TRUE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_ComboBoxControlTypeId, false, true, false, false, false, false}));
+  EXPECT_FALSE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_ComboBoxControlTypeId, false, false, false, false, false, false}));
+  EXPECT_FALSE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_ButtonControlTypeId, false, false, false, false, false, false}));
+}
+
+TEST(WindowsEditingEventMonitor, FiltersDocumentsAndReadOnlyControls) {
+  EXPECT_TRUE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_DocumentControlTypeId, true, false, false, true, false, false}));
+  EXPECT_TRUE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_DocumentControlTypeId, true, false, false, false, false, true}));
+  EXPECT_FALSE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_DocumentControlTypeId, true, false, false, false, false, false}));
+  EXPECT_FALSE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_EditControlTypeId, false, true, false, false, true, false}));
+  EXPECT_TRUE(IsWindowsTextInputCandidate(WindowsTextInputTraits{
+      UIA_DocumentControlTypeId, true, false, false, true, true, false}));
 }
 
 }  // namespace test

--- a/windows/windows_editing_event_monitor.cc
+++ b/windows/windows_editing_event_monitor.cc
@@ -1,0 +1,408 @@
+#include "windows_editing_event_monitor.h"
+
+#include "cpp_log_shim.h"
+
+#include <UIAutomation.h>
+
+#include <algorithm>
+#include <cctype>
+#include <utility>
+
+namespace hardware_simulator {
+namespace {
+
+constexpr const char *kLogTag = "EDIT_FOCUS";
+constexpr DWORD kFocusSettleDelayMs = 80;
+constexpr LONG kPointerHitTolerancePx = 8;
+constexpr int kMaximumParentDepth = 12;
+
+std::string WideToUtf8(const wchar_t *value, int length) {
+  if (value == nullptr || length <= 0) {
+    return {};
+  }
+  const int size = WideCharToMultiByte(CP_UTF8, 0, value, length, nullptr, 0,
+                                       nullptr, nullptr);
+  if (size <= 0) {
+    return {};
+  }
+  std::string result(static_cast<std::size_t>(size), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, value, length, result.data(), size, nullptr,
+                      nullptr);
+  return result;
+}
+
+std::string ToLowerAscii(std::string value) {
+  for (auto &character : value) {
+    character =
+        static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+  }
+  return value;
+}
+
+std::string ProcessNameFromPid(int process_id) {
+  if (process_id <= 0) {
+    return {};
+  }
+  const HANDLE process =
+      OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id);
+  if (process == nullptr) {
+    return {};
+  }
+
+  wchar_t path[MAX_PATH] = {};
+  DWORD length = MAX_PATH;
+  std::string result;
+  if (QueryFullProcessImageNameW(process, 0, path, &length) && length > 0) {
+    const std::wstring full_path(path, length);
+    const auto separator = full_path.find_last_of(L"\\/");
+    const std::wstring name = separator == std::wstring::npos
+                                  ? full_path
+                                  : full_path.substr(separator + 1);
+    result = WideToUtf8(name.c_str(), static_cast<int>(name.size()));
+  }
+  CloseHandle(process);
+  return result;
+}
+
+bool IsKnownRichTextEditor(const std::string &process_name) {
+  return ToLowerAscii(process_name) == "winword.exe";
+}
+
+std::optional<bool> CachedOptionalBool(IUIAutomationElement *element,
+                                       PROPERTYID property_id) {
+  VARIANT value = {};
+  VariantInit(&value);
+  std::optional<bool> result;
+  if (SUCCEEDED(element->GetCachedPropertyValueEx(property_id, TRUE, &value)) &&
+      value.vt == VT_BOOL) {
+    result = value.boolVal == VARIANT_TRUE;
+  }
+  VariantClear(&value);
+  return result;
+}
+
+bool CachedBool(IUIAutomationElement *element, PROPERTYID property_id,
+                bool fallback = false) {
+  return CachedOptionalBool(element, property_id).value_or(fallback);
+}
+
+bool HasActiveTextCaret(IUIAutomationElement *element) {
+  IUnknown *pattern_unknown = nullptr;
+  if (FAILED(element->GetCachedPattern(UIA_TextPattern2Id, &pattern_unknown)) ||
+      pattern_unknown == nullptr) {
+    return false;
+  }
+
+  IUIAutomationTextPattern2 *pattern = nullptr;
+  if (FAILED(pattern_unknown->QueryInterface(IID_PPV_ARGS(&pattern))) ||
+      pattern == nullptr) {
+    pattern_unknown->Release();
+    return false;
+  }
+  pattern_unknown->Release();
+
+  BOOL active = FALSE;
+  IUIAutomationTextRange *range = nullptr;
+  const HRESULT result = pattern->GetCaretRange(&active, &range);
+  if (range != nullptr) {
+    range->Release();
+  }
+  pattern->Release();
+  return SUCCEEDED(result) && active == TRUE;
+}
+
+bool RectContainsPointWithTolerance(const RECT &bounds, const POINT &point) {
+  if (bounds.right <= bounds.left || bounds.bottom <= bounds.top) {
+    return false;
+  }
+  return point.x >= bounds.left - kPointerHitTolerancePx &&
+         point.x <= bounds.right + kPointerHitTolerancePx &&
+         point.y >= bounds.top - kPointerHitTolerancePx &&
+         point.y <= bounds.bottom + kPointerHitTolerancePx;
+}
+
+IUIAutomationCacheRequest *CreateCacheRequest(IUIAutomation *automation) {
+  IUIAutomationCacheRequest *request = nullptr;
+  if (FAILED(automation->CreateCacheRequest(&request)) || request == nullptr) {
+    return nullptr;
+  }
+
+  request->put_TreeScope(TreeScope_Element);
+  constexpr PROPERTYID properties[] = {
+      UIA_IsEnabledPropertyId,
+      UIA_IsKeyboardFocusablePropertyId,
+      UIA_ControlTypePropertyId,
+      UIA_ProcessIdPropertyId,
+      UIA_BoundingRectanglePropertyId,
+      UIA_IsPasswordPropertyId,
+      UIA_ValueIsReadOnlyPropertyId,
+      UIA_IsTextPatternAvailablePropertyId,
+      UIA_IsValuePatternAvailablePropertyId,
+      UIA_IsTextEditPatternAvailablePropertyId,
+  };
+  for (const PROPERTYID property : properties) {
+    request->AddProperty(property);
+  }
+  request->AddPattern(UIA_TextPattern2Id);
+  return request;
+}
+
+} // namespace
+
+bool IsWindowsTextInputCandidate(const WindowsTextInputTraits &traits) {
+  const bool is_edit = traits.control_type_id == UIA_EditControlTypeId;
+  const bool is_combo = traits.control_type_id == UIA_ComboBoxControlTypeId &&
+                        traits.supports_value_pattern;
+  const bool is_document =
+      traits.control_type_id == UIA_DocumentControlTypeId &&
+      (traits.has_active_text_caret ||
+       (traits.supports_text_pattern && traits.known_rich_text_editor));
+  const bool supports_editing =
+      traits.supports_text_edit_pattern || traits.has_active_text_caret;
+  const bool likely_text_input =
+      is_edit || is_combo || is_document || supports_editing;
+  if (!likely_text_input) {
+    return false;
+  }
+  if (!traits.read_only) {
+    return true;
+  }
+  return is_document &&
+         (traits.has_active_text_caret || traits.known_rich_text_editor);
+}
+
+WindowsEditingEventMonitor::WindowsEditingEventMonitor(Callback callback)
+    : callback_(std::move(callback)) {}
+
+WindowsEditingEventMonitor::~WindowsEditingEventMonitor() { Stop(); }
+
+bool WindowsEditingEventMonitor::Start() {
+  if (is_running()) {
+    return true;
+  }
+
+  stop_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  request_event_ = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+  if (stop_event_ == nullptr || request_event_ == nullptr) {
+    Stop();
+    return false;
+  }
+
+  std::promise<bool> started;
+  std::future<bool> started_future = started.get_future();
+  worker_thread_ = std::thread(&WindowsEditingEventMonitor::WorkerMain, this,
+                               std::move(started));
+  const bool success = started_future.get();
+  if (!success) {
+    Stop();
+  }
+  return success;
+}
+
+void WindowsEditingEventMonitor::Stop() {
+  if (stop_event_ != nullptr) {
+    SetEvent(stop_event_);
+  }
+  const DWORD worker_thread_id = worker_thread_id_.load();
+  if (worker_thread_id != 0) {
+    CoCancelCall(worker_thread_id, 0);
+  }
+  if (worker_thread_.joinable()) {
+    worker_thread_.join();
+  }
+  if (request_event_ != nullptr) {
+    CloseHandle(request_event_);
+    request_event_ = nullptr;
+  }
+  if (stop_event_ != nullptr) {
+    CloseHandle(stop_event_);
+    stop_event_ = nullptr;
+  }
+  std::lock_guard<std::mutex> lock(request_mutex_);
+  pending_request_.reset();
+  running_.store(false);
+}
+
+void WindowsEditingEventMonitor::InspectAfterRemoteClick() {
+  if (!is_running() || request_event_ == nullptr) {
+    return;
+  }
+  POINT point = {};
+  if (!GetCursorPos(&point)) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(request_mutex_);
+    pending_request_ = InspectionRequest{
+        point,
+        ++next_sequence_,
+    };
+  }
+  SetEvent(request_event_);
+}
+
+void WindowsEditingEventMonitor::WorkerMain(std::promise<bool> started) {
+  worker_thread_id_.store(GetCurrentThreadId());
+  const HRESULT com_result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  const bool com_initialized = SUCCEEDED(com_result);
+  const bool cancellation_enabled =
+      com_initialized && SUCCEEDED(CoEnableCallCancellation(nullptr));
+  if (com_initialized) {
+    CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
+                     IID_PPV_ARGS(&automation_));
+  }
+  const bool ready = com_initialized && automation_ != nullptr;
+  running_.store(ready);
+  started.set_value(ready);
+  if (!ready) {
+    if (cancellation_enabled) {
+      CoDisableCallCancellation(nullptr);
+    }
+    worker_thread_id_.store(0);
+    if (com_initialized) {
+      CoUninitialize();
+    }
+    return;
+  }
+
+  CPPLOG_INFO(kLogTag, "Remote-click text input inspector started");
+  HANDLE handles[] = {stop_event_, request_event_};
+  bool stopping = false;
+  while (!stopping) {
+    DWORD wait_result = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+    if (wait_result == WAIT_OBJECT_0) {
+      break;
+    }
+    if (wait_result != WAIT_OBJECT_0 + 1) {
+      break;
+    }
+
+    while (true) {
+      wait_result =
+          WaitForMultipleObjects(2, handles, FALSE, kFocusSettleDelayMs);
+      if (wait_result == WAIT_OBJECT_0) {
+        stopping = true;
+        break;
+      }
+      if (wait_result == WAIT_OBJECT_0 + 1) {
+        continue;
+      }
+      if (wait_result != WAIT_TIMEOUT) {
+        stopping = true;
+        break;
+      }
+
+      std::optional<InspectionRequest> request;
+      {
+        std::lock_guard<std::mutex> lock(request_mutex_);
+        request = pending_request_;
+        pending_request_.reset();
+      }
+      if (request.has_value()) {
+        WindowsTextInputDecision decision = Inspect(request.value());
+        bool superseded = false;
+        {
+          std::lock_guard<std::mutex> lock(request_mutex_);
+          superseded = pending_request_.has_value() &&
+                       pending_request_->sequence > request->sequence;
+        }
+        if (!superseded && callback_) {
+          callback_(decision);
+        }
+      }
+      break;
+    }
+  }
+
+  automation_->Release();
+  automation_ = nullptr;
+  running_.store(false);
+  CPPLOG_INFO(kLogTag, "Remote-click text input inspector stopped");
+  if (cancellation_enabled) {
+    CoDisableCallCancellation(nullptr);
+  }
+  worker_thread_id_.store(0);
+  CoUninitialize();
+}
+
+WindowsTextInputDecision
+WindowsEditingEventMonitor::Inspect(const InspectionRequest &request) {
+  WindowsTextInputDecision decision;
+
+  IUIAutomationCacheRequest *cache = CreateCacheRequest(automation_);
+  if (cache == nullptr) {
+    return decision;
+  }
+
+  IUIAutomationElement *element = nullptr;
+  if (FAILED(automation_->ElementFromPointBuildCache(request.point, cache,
+                                                     &element)) ||
+      element == nullptr) {
+    cache->Release();
+    return decision;
+  }
+
+  IUIAutomationTreeWalker *walker = nullptr;
+  automation_->get_ControlViewWalker(&walker);
+  for (int depth = 0; element != nullptr && depth < kMaximumParentDepth;
+       ++depth) {
+    BOOL enabled = FALSE;
+    BOOL keyboard_focusable = FALSE;
+    CONTROLTYPEID control_type = 0;
+    int process_id = 0;
+    RECT bounds = {};
+    element->get_CachedIsEnabled(&enabled);
+    element->get_CachedIsKeyboardFocusable(&keyboard_focusable);
+    element->get_CachedControlType(&control_type);
+    element->get_CachedProcessId(&process_id);
+    element->get_CachedBoundingRectangle(&bounds);
+
+    const bool supports_text =
+        CachedBool(element, UIA_IsTextPatternAvailablePropertyId);
+    const bool supports_value =
+        CachedBool(element, UIA_IsValuePatternAvailablePropertyId);
+    const bool supports_text_edit =
+        CachedBool(element, UIA_IsTextEditPatternAvailablePropertyId);
+    const bool read_only =
+        supports_value && CachedBool(element, UIA_ValueIsReadOnlyPropertyId);
+    const bool needs_caret = control_type == UIA_DocumentControlTypeId ||
+                             supports_text || supports_text_edit;
+    const bool active_caret = needs_caret && HasActiveTextCaret(element);
+    const bool known_rich_editor =
+        control_type == UIA_DocumentControlTypeId &&
+        IsKnownRichTextEditor(ProcessNameFromPid(process_id));
+    const WindowsTextInputTraits traits{
+        control_type, supports_text, supports_value,    supports_text_edit,
+        active_caret, read_only,     known_rich_editor,
+    };
+
+    const bool text_candidate = IsWindowsTextInputCandidate(traits);
+    const bool inside_bounds =
+        RectContainsPointWithTolerance(bounds, request.point);
+    if (text_candidate && enabled && keyboard_focusable && inside_bounds) {
+      decision.active = true;
+      decision.secure = CachedOptionalBool(element, UIA_IsPasswordPropertyId);
+      break;
+    }
+
+    IUIAutomationElement *parent = nullptr;
+    if (walker == nullptr ||
+        FAILED(walker->GetParentElementBuildCache(element, cache, &parent))) {
+      parent = nullptr;
+    }
+    element->Release();
+    element = parent;
+  }
+
+  if (element != nullptr) {
+    element->Release();
+  }
+  if (walker != nullptr) {
+    walker->Release();
+  }
+  cache->Release();
+  return decision;
+}
+
+} // namespace hardware_simulator

--- a/windows/windows_editing_event_monitor.cc
+++ b/windows/windows_editing_event_monitor.cc
@@ -13,6 +13,7 @@ namespace {
 
 constexpr const char *kLogTag = "EDIT_FOCUS";
 constexpr DWORD kFocusSettleDelayMs = 80;
+constexpr DWORD kWorkerStopWaitMs = 250;
 constexpr LONG kPointerHitTolerancePx = 8;
 constexpr int kMaximumParentDepth = 12;
 
@@ -149,6 +150,34 @@ IUIAutomationCacheRequest *CreateCacheRequest(IUIAutomation *automation) {
 
 } // namespace
 
+struct WindowsEditingEventMonitor::WorkerState {
+  explicit WorkerState(Callback worker_callback)
+      : callback(std::move(worker_callback)) {}
+
+  ~WorkerState() {
+    if (request_event != nullptr) {
+      CloseHandle(request_event);
+    }
+    if (stop_event != nullptr) {
+      CloseHandle(stop_event);
+    }
+    if (finished_event != nullptr) {
+      CloseHandle(finished_event);
+    }
+  }
+
+  Callback callback;
+  std::mutex callback_mutex;
+  std::atomic<bool> running = false;
+  std::atomic<DWORD> worker_thread_id = 0;
+  HANDLE stop_event = nullptr;
+  HANDLE request_event = nullptr;
+  HANDLE finished_event = nullptr;
+  std::mutex request_mutex;
+  std::optional<InspectionRequest> pending_request;
+  std::uint64_t next_sequence = 0;
+};
+
 bool IsWindowsTextInputCandidate(const WindowsTextInputTraits &traits) {
   const bool is_edit = traits.control_type_id == UIA_EditControlTypeId;
   const bool is_combo = traits.control_type_id == UIA_ComboBoxControlTypeId &&
@@ -181,16 +210,19 @@ bool WindowsEditingEventMonitor::Start() {
     return true;
   }
 
-  stop_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-  request_event_ = CreateEventW(nullptr, FALSE, FALSE, nullptr);
-  if (stop_event_ == nullptr || request_event_ == nullptr) {
+  state_ = std::make_shared<WorkerState>(callback_);
+  state_->stop_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  state_->request_event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+  state_->finished_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (state_->stop_event == nullptr || state_->request_event == nullptr ||
+      state_->finished_event == nullptr) {
     Stop();
     return false;
   }
 
   std::promise<bool> started;
   std::future<bool> started_future = started.get_future();
-  worker_thread_ = std::thread(&WindowsEditingEventMonitor::WorkerMain, this,
+  worker_thread_ = std::thread(&WindowsEditingEventMonitor::WorkerMain, state_,
                                std::move(started));
   const bool success = started_future.get();
   if (!success) {
@@ -200,31 +232,46 @@ bool WindowsEditingEventMonitor::Start() {
 }
 
 void WindowsEditingEventMonitor::Stop() {
-  if (stop_event_ != nullptr) {
-    SetEvent(stop_event_);
+  std::shared_ptr<WorkerState> state = state_;
+  if (!state) {
+    return;
   }
-  const DWORD worker_thread_id = worker_thread_id_.load();
+
+  state->running.store(false);
+  {
+    std::lock_guard<std::mutex> lock(state->callback_mutex);
+    state->callback = nullptr;
+  }
+  {
+    std::lock_guard<std::mutex> lock(state->request_mutex);
+    state->pending_request.reset();
+  }
+  SetEvent(state->stop_event);
+  const DWORD worker_thread_id = state->worker_thread_id.load();
   if (worker_thread_id != 0) {
     CoCancelCall(worker_thread_id, 0);
   }
   if (worker_thread_.joinable()) {
-    worker_thread_.join();
+    if (WaitForSingleObject(state->finished_event, kWorkerStopWaitMs) ==
+        WAIT_OBJECT_0) {
+      worker_thread_.join();
+    } else {
+      worker_thread_.detach();
+      CPPLOG_WARN(kLogTag,
+                  "UIA worker did not stop within 250 ms; detaching cleanup");
+    }
   }
-  if (request_event_ != nullptr) {
-    CloseHandle(request_event_);
-    request_event_ = nullptr;
-  }
-  if (stop_event_ != nullptr) {
-    CloseHandle(stop_event_);
-    stop_event_ = nullptr;
-  }
-  std::lock_guard<std::mutex> lock(request_mutex_);
-  pending_request_.reset();
-  running_.store(false);
+  state_.reset();
+}
+
+bool WindowsEditingEventMonitor::is_running() const {
+  const std::shared_ptr<WorkerState> state = state_;
+  return state && state->running.load();
 }
 
 void WindowsEditingEventMonitor::InspectAfterRemoteClick() {
-  if (!is_running() || request_event_ == nullptr) {
+  const std::shared_ptr<WorkerState> state = state_;
+  if (!state || !state->running.load()) {
     return;
   }
   POINT point = {};
@@ -233,41 +280,44 @@ void WindowsEditingEventMonitor::InspectAfterRemoteClick() {
   }
 
   {
-    std::lock_guard<std::mutex> lock(request_mutex_);
-    pending_request_ = InspectionRequest{
+    std::lock_guard<std::mutex> lock(state->request_mutex);
+    state->pending_request = InspectionRequest{
         point,
-        ++next_sequence_,
+        ++state->next_sequence,
     };
   }
-  SetEvent(request_event_);
+  SetEvent(state->request_event);
 }
 
-void WindowsEditingEventMonitor::WorkerMain(std::promise<bool> started) {
-  worker_thread_id_.store(GetCurrentThreadId());
+void WindowsEditingEventMonitor::WorkerMain(std::shared_ptr<WorkerState> state,
+                                            std::promise<bool> started) {
+  state->worker_thread_id.store(GetCurrentThreadId());
   const HRESULT com_result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
   const bool com_initialized = SUCCEEDED(com_result);
   const bool cancellation_enabled =
       com_initialized && SUCCEEDED(CoEnableCallCancellation(nullptr));
+  IUIAutomation *automation = nullptr;
   if (com_initialized) {
     CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
-                     IID_PPV_ARGS(&automation_));
+                     IID_PPV_ARGS(&automation));
   }
-  const bool ready = com_initialized && automation_ != nullptr;
-  running_.store(ready);
+  const bool ready = com_initialized && automation != nullptr;
+  state->running.store(ready);
   started.set_value(ready);
   if (!ready) {
     if (cancellation_enabled) {
       CoDisableCallCancellation(nullptr);
     }
-    worker_thread_id_.store(0);
+    state->worker_thread_id.store(0);
     if (com_initialized) {
       CoUninitialize();
     }
+    SetEvent(state->finished_event);
     return;
   }
 
   CPPLOG_INFO(kLogTag, "Remote-click text input inspector started");
-  HANDLE handles[] = {stop_event_, request_event_};
+  HANDLE handles[] = {state->stop_event, state->request_event};
   bool stopping = false;
   while (!stopping) {
     DWORD wait_result = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
@@ -295,56 +345,60 @@ void WindowsEditingEventMonitor::WorkerMain(std::promise<bool> started) {
 
       std::optional<InspectionRequest> request;
       {
-        std::lock_guard<std::mutex> lock(request_mutex_);
-        request = pending_request_;
-        pending_request_.reset();
+        std::lock_guard<std::mutex> lock(state->request_mutex);
+        request = state->pending_request;
+        state->pending_request.reset();
       }
       if (request.has_value()) {
-        WindowsTextInputDecision decision = Inspect(request.value());
+        WindowsTextInputDecision decision = Inspect(automation, request.value());
         bool superseded = false;
         {
-          std::lock_guard<std::mutex> lock(request_mutex_);
-          superseded = pending_request_.has_value() &&
-                       pending_request_->sequence > request->sequence;
+          std::lock_guard<std::mutex> lock(state->request_mutex);
+          superseded = state->pending_request.has_value() &&
+                       state->pending_request->sequence > request->sequence;
         }
-        if (!superseded && callback_) {
-          callback_(decision);
+        if (!superseded) {
+          std::lock_guard<std::mutex> lock(state->callback_mutex);
+          if (state->callback) {
+            state->callback(decision);
+          }
         }
       }
       break;
     }
   }
 
-  automation_->Release();
-  automation_ = nullptr;
-  running_.store(false);
+  automation->Release();
+  state->running.store(false);
   CPPLOG_INFO(kLogTag, "Remote-click text input inspector stopped");
   if (cancellation_enabled) {
     CoDisableCallCancellation(nullptr);
   }
-  worker_thread_id_.store(0);
+  state->worker_thread_id.store(0);
   CoUninitialize();
+  SetEvent(state->finished_event);
 }
 
 WindowsTextInputDecision
-WindowsEditingEventMonitor::Inspect(const InspectionRequest &request) {
+WindowsEditingEventMonitor::Inspect(IUIAutomation *automation,
+                                    const InspectionRequest &request) {
   WindowsTextInputDecision decision;
 
-  IUIAutomationCacheRequest *cache = CreateCacheRequest(automation_);
+  IUIAutomationCacheRequest *cache = CreateCacheRequest(automation);
   if (cache == nullptr) {
     return decision;
   }
 
   IUIAutomationElement *element = nullptr;
-  if (FAILED(automation_->ElementFromPointBuildCache(request.point, cache,
-                                                     &element)) ||
+  if (FAILED(automation->ElementFromPointBuildCache(request.point, cache,
+                                                    &element)) ||
       element == nullptr) {
     cache->Release();
     return decision;
   }
 
   IUIAutomationTreeWalker *walker = nullptr;
-  automation_->get_ControlViewWalker(&walker);
+  automation->get_ControlViewWalker(&walker);
   for (int depth = 0; element != nullptr && depth < kMaximumParentDepth;
        ++depth) {
     BOOL enabled = FALSE;

--- a/windows/windows_editing_event_monitor.h
+++ b/windows/windows_editing_event_monitor.h
@@ -1,0 +1,75 @@
+#ifndef HARDWARE_SIMULATOR_WINDOWS_WINDOWS_EDITING_EVENT_MONITOR_H_
+#define HARDWARE_SIMULATOR_WINDOWS_WINDOWS_EDITING_EVENT_MONITOR_H_
+
+#include <windows.h>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+struct IUIAutomation;
+
+namespace hardware_simulator {
+
+struct WindowsTextInputDecision {
+  bool active = false;
+  std::optional<bool> secure;
+};
+
+struct WindowsTextInputTraits {
+  std::int32_t control_type_id = 0;
+  bool supports_text_pattern = false;
+  bool supports_value_pattern = false;
+  bool supports_text_edit_pattern = false;
+  bool has_active_text_caret = false;
+  bool read_only = false;
+  bool known_rich_text_editor = false;
+};
+
+bool IsWindowsTextInputCandidate(const WindowsTextInputTraits &traits);
+
+class WindowsEditingEventMonitor {
+public:
+  using Callback = std::function<void(const WindowsTextInputDecision &)>;
+
+  explicit WindowsEditingEventMonitor(Callback callback);
+  ~WindowsEditingEventMonitor();
+
+  WindowsEditingEventMonitor(const WindowsEditingEventMonitor &) = delete;
+  WindowsEditingEventMonitor &
+  operator=(const WindowsEditingEventMonitor &) = delete;
+
+  bool Start();
+  void Stop();
+  void InspectAfterRemoteClick();
+  bool is_running() const { return running_.load(); }
+
+private:
+  struct InspectionRequest {
+    POINT point = {};
+    std::uint64_t sequence = 0;
+  };
+
+  void WorkerMain(std::promise<bool> started);
+  WindowsTextInputDecision Inspect(const InspectionRequest &request);
+
+  Callback callback_;
+  std::atomic<bool> running_ = false;
+  std::atomic<DWORD> worker_thread_id_ = 0;
+  std::thread worker_thread_;
+  HANDLE stop_event_ = nullptr;
+  HANDLE request_event_ = nullptr;
+  std::mutex request_mutex_;
+  std::optional<InspectionRequest> pending_request_;
+  std::uint64_t next_sequence_ = 0;
+  ::IUIAutomation *automation_ = nullptr;
+};
+
+} // namespace hardware_simulator
+
+#endif // HARDWARE_SIMULATOR_WINDOWS_WINDOWS_EDITING_EVENT_MONITOR_H_

--- a/windows/windows_editing_event_monitor.h
+++ b/windows/windows_editing_event_monitor.h
@@ -47,27 +47,24 @@ public:
   bool Start();
   void Stop();
   void InspectAfterRemoteClick();
-  bool is_running() const { return running_.load(); }
+  bool is_running() const;
 
 private:
+  struct WorkerState;
+
   struct InspectionRequest {
     POINT point = {};
     std::uint64_t sequence = 0;
   };
 
-  void WorkerMain(std::promise<bool> started);
-  WindowsTextInputDecision Inspect(const InspectionRequest &request);
+  static void WorkerMain(std::shared_ptr<WorkerState> state,
+                         std::promise<bool> started);
+  static WindowsTextInputDecision Inspect(
+      ::IUIAutomation *automation, const InspectionRequest &request);
 
   Callback callback_;
-  std::atomic<bool> running_ = false;
-  std::atomic<DWORD> worker_thread_id_ = 0;
+  std::shared_ptr<WorkerState> state_;
   std::thread worker_thread_;
-  HANDLE stop_event_ = nullptr;
-  HANDLE request_event_ = nullptr;
-  std::mutex request_mutex_;
-  std::optional<InspectionRequest> pending_request_;
-  std::uint64_t next_sequence_ = 0;
-  ::IUIAutomation *automation_ = nullptr;
 };
 
 } // namespace hardware_simulator


### PR DESCRIPTION
﻿## Summary

- inspect Windows UI Automation once, 80 ms after an injected remote left-button release
- expose a minimal Dart decision API containing only active and nullable secure
- classify Edit, ComboBox, Document, TextEdit, active-caret, read-only, password, and Word rich-text cases
- add an example page that displays only the final show/hide decision and password state

## Performance and privacy

- no WH_MOUSE_LL hook, WinEvent subscription, UIA focus subscription, or polling
- no worker or COM/UIA object before the first listener; the idle worker blocks on event handles
- UIA work runs off the Flutter platform, render, and decode threads
- consecutive clicks during the 80 ms settle window keep only the latest request
- COM call cancellation prevents a stalled provider from blocking teardown
- no control name, AutomationId, value, selection, or text crosses the MethodChannel
- native logging remains a no-op when CPP_LOG_AVAILABLE is absent

This keeps the useful filters from the closed draft #25 without its global monitoring path.

## Validation

- flutter test: 11 tests passed
- example widget test: passed
- targeted Flutter analysis: no issues
- Windows native Release build: 0 warnings, 0 errors
- Windows example Release build: passed

Local preview:
D:\Dev\cloudplayplus2026\.codex-worktrees\hardware_simulator-edit-focus\example\build\plugin-pr-preview\windows\x64\runner\Release\hardware_simulator_example.exe
