### PR TITLE
feat(windows): inject committed Unicode text

### DIFF
--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -69,8 +69,16 @@ class HWMouse {
   }
 
   // mouse left button id 1, right button id 3
-  void performMouseClick(int buttonId, bool isDown) {
-    HardwareSimulatorPlatform.instance.performMouseClick(buttonId, isDown);
+  void performMouseClick(
+    int buttonId,
+    bool isDown, {
+    int? editFocusRequestId,
+  }) {
+    HardwareSimulatorPlatform.instance.performMouseClick(
+      buttonId,
+      isDown,
+      editFocusRequestId: editFocusRequestId,
+    );
   }
 
   /// Injects a canonical logical scroll delta.
@@ -335,9 +343,21 @@ class HardwareSimulator {
   }
 
   static void performTouchEvent(
-      double x, double y, int touchId, bool isDown, int screenId) {
-    HardwareSimulatorPlatform.instance
-        .performTouchEvent(x, y, touchId, isDown, screenId);
+    double x,
+    double y,
+    int touchId,
+    bool isDown,
+    int screenId, {
+    int? editFocusRequestId,
+  }) {
+    HardwareSimulatorPlatform.instance.performTouchEvent(
+      x,
+      y,
+      touchId,
+      isDown,
+      screenId,
+      editFocusRequestId: editFocusRequestId,
+    );
   }
 
   static void performTouchMove(double x, double y, int touchId, int screenId) {
@@ -345,10 +365,28 @@ class HardwareSimulator {
         .performTouchMove(x, y, touchId, screenId);
   }
 
-  static void performPenEvent(double x, double y, bool isDown, bool hasButton,
-      double pressure, double rotation, double tilt, int screenId) {
+  static void performPenEvent(
+    double x,
+    double y,
+    bool isDown,
+    bool hasButton,
+    double pressure,
+    double rotation,
+    double tilt,
+    int screenId, {
+    int? editFocusRequestId,
+  }) {
     HardwareSimulatorPlatform.instance.performPenEvent(
-        x, y, isDown, hasButton, pressure, rotation, tilt, screenId);
+      x,
+      y,
+      isDown,
+      hasButton,
+      pressure,
+      rotation,
+      tilt,
+      screenId,
+      editFocusRequestId: editFocusRequestId,
+    );
   }
 
   static void performPenMove(double x, double y, bool hasButton,

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -44,6 +44,11 @@ class HWKeyboard {
   void performKeyEvent(int keyCode, bool isDown) {
     HardwareSimulatorPlatform.instance.performKeyEvent(keyCode, isDown);
   }
+
+  /// Injects committed text without exposing its contents to Dart-side logs.
+  Future<void> performTextInput(String text) {
+    return HardwareSimulatorPlatform.instance.performTextInput(text);
+  }
 }
 
 class HWMouse {

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -478,10 +478,15 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   }
 
   @override
-  Future<void> performMouseClick(int buttonId, bool isDown) async {
+  Future<void> performMouseClick(
+    int buttonId,
+    bool isDown, {
+    int? editFocusRequestId,
+  }) async {
     await methodChannel.invokeMethod('mousePress', {
       'buttonId': buttonId,
       'isDown': isDown,
+      if (editFocusRequestId != null) 'editFocusRequestId': editFocusRequestId,
     });
   }
 
@@ -530,13 +535,20 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
 
   @override
   Future<void> performTouchEvent(
-      double x, double y, int touchId, bool isDown, int screenId) async {
+    double x,
+    double y,
+    int touchId,
+    bool isDown,
+    int screenId, {
+    int? editFocusRequestId,
+  }) async {
     await methodChannel.invokeMethod('touchEvent', {
       'x': x,
       'y': y,
       'touchId': touchId,
       'isDown': isDown,
       'screenId': screenId,
+      if (editFocusRequestId != null) 'editFocusRequestId': editFocusRequestId,
     });
   }
 
@@ -552,8 +564,17 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
   }
 
   @override
-  Future<void> performPenEvent(double x, double y, bool isDown, bool hasButton,
-      double pressure, double rotation, double tilt, int screenId) async {
+  Future<void> performPenEvent(
+    double x,
+    double y,
+    bool isDown,
+    bool hasButton,
+    double pressure,
+    double rotation,
+    double tilt,
+    int screenId, {
+    int? editFocusRequestId,
+  }) async {
     await methodChannel.invokeMethod('penEvent', {
       'x': x,
       'y': y,
@@ -563,6 +584,7 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
       'rotation': rotation,
       'tilt': tilt,
       'screenId': screenId,
+      if (editFocusRequestId != null) 'editFocusRequestId': editFocusRequestId,
     });
   }
 

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -441,6 +441,11 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
     });
   }
 
+  @override
+  Future<void> performTextInput(String text) async {
+    await methodChannel.invokeMethod('performTextInput', {'text': text});
+  }
+
   // Relative mouse movement.
   @override
   Future<void> performMouseMoveRelative(

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -58,16 +58,17 @@ class TrackpadScrollEvent {
   final bool isMomentum;
 }
 
-/// 远端左键抬起后，Windows UI Automation 给出的软件盘决策。
+/// 远端主鼠标、触摸或笔抬起后，Windows UI Automation 给出的软件盘决策。
 ///
 /// [active] 为 true 时应弹出软件盘，否则应收起。[secure] 只在 UIA 明确判断
 /// 当前可编辑控件是否为密码框时取 true 或 false；无法确认或 [active] 为 false
-/// 时为 null。
+/// 时为 null。[editFocusRequestId] 原样返回触发检查的 Dart 请求标识。
 @immutable
 class WindowsTextInputDecision {
   const WindowsTextInputDecision({
     required this.active,
     required this.secure,
+    this.editFocusRequestId,
   });
 
   factory WindowsTextInputDecision.fromMap(Map<Object?, Object?> map) {
@@ -76,11 +77,15 @@ class WindowsTextInputDecision {
     return WindowsTextInputDecision(
       active: active,
       secure: active && secure is bool ? secure : null,
+      editFocusRequestId: map['editFocusRequestId'] is int
+          ? map['editFocusRequestId'] as int
+          : null,
     );
   }
 
   final bool active;
   final bool? secure;
+  final int? editFocusRequestId;
 }
 
 abstract class HardwareSimulatorPlatform extends PlatformInterface {
@@ -315,7 +320,11 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
         'performMouseMoveToWindowPosition() has not been implemented.');
   }
 
-  Future<void> performMouseClick(int buttonId, bool isDown) async {
+  Future<void> performMouseClick(
+    int buttonId,
+    bool isDown, {
+    int? editFocusRequestId,
+  }) async {
     throw UnimplementedError('performMouseClick() has not been implemented.');
   }
 
@@ -337,7 +346,13 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
 
   // Touch event simulation
   Future<void> performTouchEvent(
-      double x, double y, int touchId, bool isDown, int screenId) async {
+    double x,
+    double y,
+    int touchId,
+    bool isDown,
+    int screenId, {
+    int? editFocusRequestId,
+  }) async {
     throw UnimplementedError('performTouchEvent() has not been implemented.');
   }
 
@@ -347,8 +362,17 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   }
 
   // Pen event simulation
-  Future<void> performPenEvent(double x, double y, bool isDown, bool hasButton,
-      double pressure, double rotation, double tilt, int screenId) async {
+  Future<void> performPenEvent(
+    double x,
+    double y,
+    bool isDown,
+    bool hasButton,
+    double pressure,
+    double rotation,
+    double tilt,
+    int screenId, {
+    int? editFocusRequestId,
+  }) async {
     throw UnimplementedError('performPenEvent() has not been implemented.');
   }
 

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -290,6 +290,10 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
     throw UnimplementedError('performKeyEvent() has not been implemented.');
   }
 
+  Future<void> performTextInput(String text) async {
+    throw UnimplementedError('performTextInput() has not been implemented.');
+  }
+
   // Relative mouse movement.
   Future<void> performMouseMoveRelative(
       double deltax, double deltay, int screenId) async {

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -47,6 +47,68 @@ void main() {
     expect(calls.single.arguments, {'text': '你好 👋'});
   });
 
+  test('pointer contact-up carries the edit-focus request id', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        return null;
+      },
+    );
+
+    await platform.performMouseClick(
+      1,
+      false,
+      editFocusRequestId: 41,
+    );
+    await platform.performTouchEvent(
+      0.25,
+      0.75,
+      2,
+      false,
+      1,
+      editFocusRequestId: 42,
+    );
+    await platform.performPenEvent(
+      0.5,
+      0.6,
+      false,
+      false,
+      0.8,
+      0,
+      0,
+      1,
+      editFocusRequestId: 43,
+    );
+
+    expect(calls[0].arguments, {
+      'buttonId': 1,
+      'isDown': false,
+      'editFocusRequestId': 41,
+    });
+    expect(calls[1].arguments, {
+      'x': 0.25,
+      'y': 0.75,
+      'touchId': 2,
+      'isDown': false,
+      'screenId': 1,
+      'editFocusRequestId': 42,
+    });
+    expect(calls[2].arguments, {
+      'x': 0.5,
+      'y': 0.6,
+      'isDown': false,
+      'hasButton': false,
+      'pressure': 0.8,
+      'rotation': 0.0,
+      'tilt': 0.0,
+      'screenId': 1,
+      'editFocusRequestId': 43,
+    });
+  });
+
   test('performPenHover sends penHover method call', () async {
     final calls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -277,6 +339,7 @@ void main() {
         const MethodCall('onWindowsTextInputDecision', <String, dynamic>{
           'active': true,
           'secure': false,
+          'editFocusRequestId': 42,
         }),
       ),
       null,
@@ -285,6 +348,7 @@ void main() {
     expect(received, isNotNull);
     expect(received!.active, isTrue);
     expect(received!.secure, isFalse);
+    expect(received!.editFocusRequestId, 42);
     await Future<void>.delayed(Duration.zero);
   });
 

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -28,6 +28,25 @@ void main() {
     expect(await platform.getPlatformVersion(), '42');
   });
 
+  test('performTextInput sends committed text without transformation',
+      () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        calls.add(methodCall);
+        return null;
+      },
+    );
+
+    await platform.performTextInput('你好 👋');
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'performTextInput');
+    expect(calls.single.arguments, {'text': '你好 👋'});
+  });
+
   test('performPenHover sends penHover method call', () async {
     final calls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,8 @@ list(APPEND PLUGIN_SOURCES
   "trackpad_scroll_accumulator.h"
   "windows_editing_event_monitor.cc"
   "windows_editing_event_monitor.h"
+  "windows_text_input_injector.cc"
+  "windows_text_input_injector.h"
   "virtual_display.cc"
   "virtual_display.h"
   "virtual_display_control.cc"

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -98,6 +98,24 @@ bool adjust_touch_to_screen(
     LONG& out_x,
     LONG& out_y);
 
+std::optional<POINT> NormalizedPointOnMonitor(
+    const RECT& monitor_rect,
+    double x_percent,
+    double y_percent) {
+  if (!std::isfinite(x_percent) || !std::isfinite(y_percent) ||
+      monitor_rect.right <= monitor_rect.left ||
+      monitor_rect.bottom <= monitor_rect.top) {
+    return std::nullopt;
+  }
+  return POINT{
+      monitor_rect.left + static_cast<LONG>(
+                              (monitor_rect.right - monitor_rect.left) *
+                              x_percent),
+      monitor_rect.top + static_cast<LONG>(
+                             (monitor_rect.bottom - monitor_rect.top) *
+                             y_percent)};
+}
+
 std::optional<POINT> PointerPointForScreen(
     int screen_id,
     double x,
@@ -401,26 +419,14 @@ bool adjust_touch_to_screen(int screen_index, double x_percent, double y_percent
         return false;
     }
 
-    RECT global_bounds = {0};
-    for (const auto& monitor : monitors) {
-        global_bounds.left = (std::min)(global_bounds.left, monitor.rect.left);
-        global_bounds.top = (std::min)(global_bounds.top, monitor.rect.top);
-        global_bounds.right = (std::max)(global_bounds.right, monitor.rect.right);
-        global_bounds.bottom = (std::max)(global_bounds.bottom, monitor.rect.bottom);
+    const auto point = NormalizedPointOnMonitor(
+        monitors[screen_index].rect, x_percent, y_percent);
+    if (!point.has_value()) {
+        out_x = out_y = 0;
+        return false;
     }
-
-    const auto& screen = monitors[screen_index];
-    
-    double global_x = (screen.rect.left - global_bounds.left + 
-                      (screen.rect.right - screen.rect.left) * x_percent) / 
-                     (global_bounds.right - global_bounds.left);
-    
-    double global_y = (screen.rect.top - global_bounds.top + 
-                      (screen.rect.bottom - screen.rect.top) * y_percent) / 
-                     (global_bounds.bottom - global_bounds.top);
-
-    out_x = static_cast<LONG>(global_x * GetSystemMetrics(SM_CXVIRTUALSCREEN));
-    out_y = static_cast<LONG>(global_y * GetSystemMetrics(SM_CYVIRTUALSCREEN));
+    out_x = point->x;
+    out_y = point->y;
     return true;
 }
 

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -28,6 +28,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <thread>
 
@@ -69,6 +70,44 @@ int logicalScrollToWindowsWheel(double logical_distance, bool invert) {
   const double clamped = (std::clamp)(
       scaled, -kMaxWindowsWheelDistance, kMaxWindowsWheelDistance);
   return static_cast<int>(std::lround(clamped));
+}
+
+std::optional<std::int64_t> ReadOptionalInt64(
+    const flutter::EncodableMap* args,
+    const char* key) {
+  if (args == nullptr) {
+    return std::nullopt;
+  }
+  const auto iterator = args->find(flutter::EncodableValue(key));
+  if (iterator == args->end()) {
+    return std::nullopt;
+  }
+  if (const auto value = std::get_if<std::int32_t>(&iterator->second)) {
+    return static_cast<std::int64_t>(*value);
+  }
+  if (const auto value = std::get_if<std::int64_t>(&iterator->second)) {
+    return *value;
+  }
+  return std::nullopt;
+}
+
+bool adjust_touch_to_screen(
+    int screen_index,
+    double x_percent,
+    double y_percent,
+    LONG& out_x,
+    LONG& out_y);
+
+std::optional<POINT> PointerPointForScreen(
+    int screen_id,
+    double x,
+    double y) {
+  LONG point_x = 0;
+  LONG point_y = 0;
+  if (!adjust_touch_to_screen(screen_id, x, y, point_x, point_y)) {
+    return std::nullopt;
+  }
+  return POINT{point_x, point_y};
 }
 
 LRESULT CALLBACK CursorReseedSubclassProc(
@@ -1160,6 +1199,10 @@ void HardwareSimulatorPlugin::SendWindowsTextInputDecision(
       decision.secure.has_value()
           ? flutter::EncodableValue(decision.secure.value())
           : flutter::EncodableValue();
+  message[flutter::EncodableValue("editFocusRequestId")] =
+      decision.edit_focus_request_id.has_value()
+          ? flutter::EncodableValue(decision.edit_focus_request_id.value())
+          : flutter::EncodableValue();
   channel_->InvokeMethod(
       "onWindowsTextInputDecision",
       std::make_unique<flutter::EncodableValue>(message));
@@ -1626,9 +1669,12 @@ void HardwareSimulatorPlugin::HandleMethodCall(
         auto isDown = (args->find(flutter::EncodableValue("isDown")))->second;
         const int button = static_cast<int>(std::get<int>(buttonid));
         const bool is_down = static_cast<bool>(std::get<bool>(isDown));
+        const auto edit_focus_request_id =
+            ReadOptionalInt64(args, "editFocusRequestId");
         performMouseButton(button, !is_down);
         if (button == 1 && !is_down && windows_editing_event_monitor_) {
-          windows_editing_event_monitor_->InspectAfterRemoteClick();
+          windows_editing_event_monitor_->InspectAfterRemotePointerUp(
+              edit_focus_request_id);
         }
         result->Success(nullptr);
   } else if (method_call.method_name().compare("mouseScroll") == 0) {
@@ -1750,13 +1796,25 @@ void HardwareSimulatorPlugin::HandleMethodCall(
         auto y = (args->find(flutter::EncodableValue("y")))->second;
         auto touchId = (args->find(flutter::EncodableValue("touchId")))->second;
         auto isDown = (args->find(flutter::EncodableValue("isDown")))->second;
+        const int screen_id = static_cast<int>(std::get<int>((screenId)));
+        const double x_value = static_cast<double>(std::get<double>((x)));
+        const double y_value = static_cast<double>(std::get<double>((y)));
+        const bool is_down = static_cast<bool>(std::get<bool>((isDown)));
         performTouchEvent(
-            static_cast<int>(std::get<int>((screenId))),
-            static_cast<double>(std::get<double>((x))),
-            static_cast<double>(std::get<double>((y))),
+            screen_id,
+            x_value,
+            y_value,
             static_cast<uint32_t>(std::get<int>((touchId))),
-            static_cast<bool>(std::get<bool>((isDown)))
+            is_down
         );
+        const auto inspection_point =
+            PointerPointForScreen(screen_id, x_value, y_value);
+        if (!is_down && windows_editing_event_monitor_ &&
+            inspection_point.has_value()) {
+          windows_editing_event_monitor_->InspectAfterRemotePointerUp(
+              ReadOptionalInt64(args, "editFocusRequestId"),
+              inspection_point);
+        }
         result->Success(nullptr);
   } else if (method_call.method_name().compare("touchMove") == 0) {
         auto screenId = (args->find(flutter::EncodableValue("screenId")))->second;
@@ -1779,16 +1837,28 @@ void HardwareSimulatorPlugin::HandleMethodCall(
         auto pressure = (args->find(flutter::EncodableValue("pressure")))->second;
         auto rotation = (args->find(flutter::EncodableValue("rotation")))->second;
         auto tilt = (args->find(flutter::EncodableValue("tilt")))->second;
+        const int screen_id = static_cast<int>(std::get<int>((screenId)));
+        const double x_value = static_cast<double>(std::get<double>((x)));
+        const double y_value = static_cast<double>(std::get<double>((y)));
+        const bool is_down = static_cast<bool>(std::get<bool>((isDown)));
         performPenEvent(
-            static_cast<int>(std::get<int>((screenId))),
-            static_cast<double>(std::get<double>((x))),
-            static_cast<double>(std::get<double>((y))),
-            static_cast<bool>(std::get<bool>((isDown))),
+            screen_id,
+            x_value,
+            y_value,
+            is_down,
             static_cast<bool>(std::get<bool>((hasButton))),
             static_cast<double>(std::get<double>((pressure))),
             static_cast<double>(std::get<double>((rotation))),
             static_cast<double>(std::get<double>((tilt)))
         );
+        const auto inspection_point =
+            PointerPointForScreen(screen_id, x_value, y_value);
+        if (!is_down && windows_editing_event_monitor_ &&
+            inspection_point.has_value()) {
+          windows_editing_event_monitor_->InspectAfterRemotePointerUp(
+              ReadOptionalInt64(args, "editFocusRequestId"),
+              inspection_point);
+        }
         result->Success(nullptr);
   } else if (method_call.method_name().compare("penMove") == 0) {
         auto screenId = (args->find(flutter::EncodableValue("screenId")))->second;

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -7,6 +7,7 @@
 #include "trackpad_scroll_accumulator.h"
 #include "virtual_display_control.h"
 #include "windows_editing_event_monitor.h"
+#include "windows_text_input_injector.h"
 #include "SmartKeyboardBlocker.h"
 
 // This must be included before many other Windows headers.
@@ -1582,6 +1583,27 @@ void HardwareSimulatorPlugin::HandleMethodCall(
         auto keyCode = (args->find(flutter::EncodableValue("code")))->second;
         auto isDown = (args->find(flutter::EncodableValue("isDown")))->second;
         performKeyEvent(static_cast<int>(std::get<int>((keyCode))), static_cast<bool>(std::get<bool>((isDown))));
+        result->Success(nullptr);
+  } else if (method_call.method_name().compare("performTextInput") == 0) {
+        if (!args) {
+          result->Error("INVALID_TEXT", "Missing text input arguments");
+          return;
+        }
+        const auto text_iter = args->find(flutter::EncodableValue("text"));
+        if (text_iter == args->end() ||
+            !std::holds_alternative<std::string>(text_iter->second)) {
+          result->Error("INVALID_TEXT", "Text input must be a string");
+          return;
+        }
+        std::vector<INPUT> inputs;
+        if (!BuildWindowsUnicodeTextInputs(
+                std::get<std::string>(text_iter->second), &inputs)) {
+          result->Error("INVALID_TEXT", "Text input is invalid or too long");
+          return;
+        }
+        for (auto& input : inputs) {
+          send_input(input);
+        }
         result->Success(nullptr);
   } else if (method_call.method_name().compare("mouseMoveR") == 0) {
         auto deltax = (args->find(flutter::EncodableValue("x")))->second;

--- a/windows/hardware_simulator_plugin.h
+++ b/windows/hardware_simulator_plugin.h
@@ -25,6 +25,13 @@ namespace hardware_simulator {
 class WindowsEditingEventMonitor;
 struct WindowsTextInputDecision;
 
+// Converts monitor-local normalized coordinates into physical virtual-desktop
+// pixels. The result intentionally preserves negative virtual origins.
+std::optional<POINT> NormalizedPointOnMonitor(
+    const RECT& monitor_rect,
+    double x_percent,
+    double y_percent);
+
 class HardwareSimulatorPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);

--- a/windows/test/hardware_simulator_plugin_test.cpp
+++ b/windows/test/hardware_simulator_plugin_test.cpp
@@ -43,6 +43,24 @@ TEST(HardwareSimulatorPlugin, GetPlatformVersion) {
   EXPECT_TRUE(result_string.rfind("Windows ", 0) == 0);
 }
 
+TEST(PointerCoordinates, PreservesNegativeVirtualDesktopOrigin) {
+  const RECT left_monitor = {-1920, 0, 0, 1080};
+  const auto left_center =
+      NormalizedPointOnMonitor(left_monitor, 0.5, 0.5);
+
+  ASSERT_TRUE(left_center.has_value());
+  EXPECT_EQ(left_center->x, -960);
+  EXPECT_EQ(left_center->y, 540);
+
+  const RECT upper_monitor = {0, -1200, 1920, 0};
+  const auto upper_center =
+      NormalizedPointOnMonitor(upper_monitor, 0.5, 0.5);
+
+  ASSERT_TRUE(upper_center.has_value());
+  EXPECT_EQ(upper_center->x, 960);
+  EXPECT_EQ(upper_center->y, -600);
+}
+
 TEST(TrackpadScrollAccumulator, PreservesIntegralInputDistance) {
   TrackpadScrollAccumulator accumulator(12000);
 

--- a/windows/test/hardware_simulator_plugin_test.cpp
+++ b/windows/test/hardware_simulator_plugin_test.cpp
@@ -12,6 +12,7 @@
 #include "hardware_simulator_plugin.h"
 #include "trackpad_scroll_accumulator.h"
 #include "windows_editing_event_monitor.h"
+#include "windows_text_input_injector.h"
 
 namespace hardware_simulator {
 namespace test {
@@ -65,6 +66,51 @@ TEST(TrackpadScrollAccumulator, CarriesSubunitFramesPerAxis) {
   EXPECT_EQ(vertical.Convert(1, true), -1);
   EXPECT_EQ(vertical.Convert(1, true), -1);
   EXPECT_EQ(vertical.Convert(1, true), -1);
+}
+
+TEST(WindowsTextInputInjector, BuildsUnicodeKeyPairs) {
+  std::vector<INPUT> inputs;
+
+  ASSERT_TRUE(BuildWindowsUnicodeTextInputs("A\xE4\xBD\xA0", &inputs));
+  ASSERT_EQ(inputs.size(), 4u);
+  EXPECT_EQ(inputs[0].type, INPUT_KEYBOARD);
+  EXPECT_EQ(inputs[0].ki.wVk, 0);
+  EXPECT_EQ(inputs[0].ki.wScan, L'A');
+  EXPECT_EQ(inputs[0].ki.dwFlags, KEYEVENTF_UNICODE);
+  EXPECT_EQ(inputs[1].ki.wScan, L'A');
+  EXPECT_EQ(inputs[1].ki.dwFlags, KEYEVENTF_UNICODE | KEYEVENTF_KEYUP);
+  EXPECT_EQ(inputs[2].ki.wScan, 0x4F60);
+  EXPECT_EQ(inputs[2].ki.dwFlags, KEYEVENTF_UNICODE);
+  EXPECT_EQ(inputs[3].ki.wScan, 0x4F60);
+  EXPECT_EQ(inputs[3].ki.dwFlags, KEYEVENTF_UNICODE | KEYEVENTF_KEYUP);
+}
+
+TEST(WindowsTextInputInjector, PreservesSurrogatePairs) {
+  std::vector<INPUT> inputs;
+
+  ASSERT_TRUE(
+      BuildWindowsUnicodeTextInputs("\xF0\x9F\x91\x8B", &inputs));
+  ASSERT_EQ(inputs.size(), 4u);
+  EXPECT_EQ(inputs[0].ki.wScan, 0xD83D);
+  EXPECT_EQ(inputs[1].ki.wScan, 0xD83D);
+  EXPECT_EQ(inputs[2].ki.wScan, 0xDC4B);
+  EXPECT_EQ(inputs[3].ki.wScan, 0xDC4B);
+}
+
+TEST(WindowsTextInputInjector, RejectsInvalidOrUnsafeTextAtomically) {
+  std::vector<INPUT> inputs(1);
+  const std::vector<INPUT> original = inputs;
+
+  EXPECT_FALSE(BuildWindowsUnicodeTextInputs("", &inputs));
+  EXPECT_EQ(inputs.size(), original.size());
+  EXPECT_FALSE(BuildWindowsUnicodeTextInputs("line\nfeed", &inputs));
+  EXPECT_EQ(inputs.size(), original.size());
+  EXPECT_FALSE(BuildWindowsUnicodeTextInputs("\x7F", &inputs));
+  EXPECT_EQ(inputs.size(), original.size());
+  EXPECT_FALSE(BuildWindowsUnicodeTextInputs("\xC3\x28", &inputs));
+  EXPECT_EQ(inputs.size(), original.size());
+  EXPECT_FALSE(BuildWindowsUnicodeTextInputs(std::string(4097, 'a'), &inputs));
+  EXPECT_EQ(inputs.size(), original.size());
 }
 
 TEST(WindowsEditingEventMonitor, ClassifiesEditableControls) {

--- a/windows/windows_editing_event_monitor.cc
+++ b/windows/windows_editing_event_monitor.cc
@@ -269,21 +269,26 @@ bool WindowsEditingEventMonitor::is_running() const {
   return state && state->running.load();
 }
 
-void WindowsEditingEventMonitor::InspectAfterRemoteClick() {
+void WindowsEditingEventMonitor::InspectAfterRemotePointerUp(
+    std::optional<std::int64_t> edit_focus_request_id,
+    std::optional<POINT> point) {
   const std::shared_ptr<WorkerState> state = state_;
   if (!state || !state->running.load()) {
     return;
   }
-  POINT point = {};
-  if (!GetCursorPos(&point)) {
+  POINT inspection_point = {};
+  if (point.has_value()) {
+    inspection_point = point.value();
+  } else if (!GetCursorPos(&inspection_point)) {
     return;
   }
 
   {
     std::lock_guard<std::mutex> lock(state->request_mutex);
     state->pending_request = InspectionRequest{
-        point,
+        inspection_point,
         ++state->next_sequence,
+        edit_focus_request_id,
     };
   }
   SetEvent(state->request_event);
@@ -383,6 +388,7 @@ WindowsTextInputDecision
 WindowsEditingEventMonitor::Inspect(IUIAutomation *automation,
                                     const InspectionRequest &request) {
   WindowsTextInputDecision decision;
+  decision.edit_focus_request_id = request.edit_focus_request_id;
 
   IUIAutomationCacheRequest *cache = CreateCacheRequest(automation);
   if (cache == nullptr) {

--- a/windows/windows_editing_event_monitor.h
+++ b/windows/windows_editing_event_monitor.h
@@ -19,6 +19,7 @@ namespace hardware_simulator {
 struct WindowsTextInputDecision {
   bool active = false;
   std::optional<bool> secure;
+  std::optional<std::int64_t> edit_focus_request_id;
 };
 
 struct WindowsTextInputTraits {
@@ -46,7 +47,9 @@ public:
 
   bool Start();
   void Stop();
-  void InspectAfterRemoteClick();
+  void InspectAfterRemotePointerUp(
+      std::optional<std::int64_t> edit_focus_request_id,
+      std::optional<POINT> point = std::nullopt);
   bool is_running() const;
 
 private:
@@ -55,6 +58,7 @@ private:
   struct InspectionRequest {
     POINT point = {};
     std::uint64_t sequence = 0;
+    std::optional<std::int64_t> edit_focus_request_id;
   };
 
   static void WorkerMain(std::shared_ptr<WorkerState> state,

--- a/windows/windows_text_input_injector.cc
+++ b/windows/windows_text_input_injector.cc
@@ -1,0 +1,56 @@
+#include "windows_text_input_injector.h"
+
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace hardware_simulator {
+
+bool BuildWindowsUnicodeTextInputs(const std::string& utf8_text,
+                                   std::vector<INPUT>* inputs) {
+  if (inputs == nullptr || utf8_text.empty() ||
+      utf8_text.size() > kMaxTextInputUtf8Bytes ||
+      utf8_text.size() > static_cast<size_t>((std::numeric_limits<int>::max)())) {
+    return false;
+  }
+
+  const int utf8_size = static_cast<int>(utf8_text.size());
+  const int utf16_size = MultiByteToWideChar(
+      CP_UTF8, MB_ERR_INVALID_CHARS, utf8_text.data(), utf8_size, nullptr, 0);
+  if (utf16_size <= 0) {
+    return false;
+  }
+
+  std::wstring utf16(static_cast<size_t>(utf16_size), L'\0');
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_text.data(),
+                          utf8_size, utf16.data(), utf16_size) != utf16_size) {
+    return false;
+  }
+
+  for (const wchar_t code_unit : utf16) {
+    if (code_unit < 0x20 || code_unit == 0x7f) {
+      return false;
+    }
+  }
+
+  std::vector<INPUT> sequence;
+  sequence.reserve(utf16.size() * 2);
+  for (const wchar_t code_unit : utf16) {
+    INPUT down{};
+    down.type = INPUT_KEYBOARD;
+    down.ki.wVk = 0;
+    down.ki.wScan = static_cast<WORD>(code_unit);
+    down.ki.dwFlags = KEYEVENTF_UNICODE;
+    sequence.push_back(down);
+
+    INPUT up = down;
+    up.ki.dwFlags |= KEYEVENTF_KEYUP;
+    sequence.push_back(up);
+  }
+
+  *inputs = std::move(sequence);
+  return true;
+}
+
+}  // namespace hardware_simulator

--- a/windows/windows_text_input_injector.h
+++ b/windows/windows_text_input_injector.h
@@ -1,0 +1,21 @@
+#ifndef HARDWARE_SIMULATOR_WINDOWS_TEXT_INPUT_INJECTOR_H_
+#define HARDWARE_SIMULATOR_WINDOWS_TEXT_INPUT_INJECTOR_H_
+
+#include <windows.h>
+
+#include <string>
+#include <vector>
+
+namespace hardware_simulator {
+
+constexpr size_t kMaxTextInputUtf8Bytes = 4096;
+
+// Builds the exact INPUT_KEYBOARD sequence used for committed IME text.
+// Returns false without producing a partial sequence when UTF-8 is malformed,
+// empty, over the protocol limit, or contains C0/DEL control characters.
+bool BuildWindowsUnicodeTextInputs(const std::string& utf8_text,
+                                   std::vector<INPUT>* inputs);
+
+}  // namespace hardware_simulator
+
+#endif  // HARDWARE_SIMULATOR_WINDOWS_TEXT_INPUT_INJECTOR_H_


### PR DESCRIPTION
## Summary
- expose `performTextInput(String text)` through the plugin Dart API
- validate committed UTF-8 atomically and build `KEYEVENTF_UNICODE` down/up pairs on Windows
- preserve surrogate pairs, reject C0/DEL and payloads over 4 KiB, and reuse the Desktop Service input route
- carry an optional Host-local edit-focus request ID through native inspection and return it with the decision
- trigger edit-focus inspection after primary mouse, touch, and pen release, using the injected touch/pen point

## Verification
- `flutter test` (13 passed)
- Windows release example build
- Windows native `hardware_simulator_test.exe` (9 passed, including Unicode injector and negative virtual-origin coverage)
- consumed by CloudPlayPlus/cloudplayplus#473

Related design: CloudPlayPlus/cloudplayplus_book#34