### PR TITLE
feat(macos): add native editable-focus text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add event-driven macOS editable-focus detection and Unicode text injection.
+* Generalize the editable-focus decision API for Windows and macOS hosts.
 * Derive injected macOS keyboard flags from remote pressed modifiers so
   back-to-back shortcuts keep their Command/Control state reliably.
 * Inject macOS Caps Lock as explicit AlphaShift state changes so repeated

--- a/example/lib/windows_editing_events_example.dart
+++ b/example/lib/windows_editing_events_example.dart
@@ -15,7 +15,7 @@ class _WindowsEditingEventsExampleState
   bool _listening = false;
   bool _injectingTestClick = false;
   bool? _showKeyboard;
-  WindowsTextInputDecision? _lastDecision;
+  TextInputDecision? _lastDecision;
   int _inspectionCount = 0;
   int _decisionChangeCount = 0;
 
@@ -28,20 +28,20 @@ class _WindowsEditingEventsExampleState
   @override
   void dispose() {
     if (_listening) {
-      HardwareSimulator.removeWindowsTextInputDecision(_onDecision);
+      HardwareSimulator.removeTextInputDecision(_onDecision);
     }
     super.dispose();
   }
 
   void _startListening() {
     if (_listening) return;
-    HardwareSimulator.addWindowsTextInputDecision(_onDecision);
+    HardwareSimulator.addTextInputDecision(_onDecision);
     setState(() => _listening = true);
   }
 
   void _stopListening() {
     if (!_listening) return;
-    HardwareSimulator.removeWindowsTextInputDecision(_onDecision);
+    HardwareSimulator.removeTextInputDecision(_onDecision);
     setState(() => _listening = false);
   }
 
@@ -54,7 +54,7 @@ class _WindowsEditingEventsExampleState
     });
   }
 
-  void _onDecision(WindowsTextInputDecision decision) {
+  void _onDecision(TextInputDecision decision) {
     if (!mounted) return;
     setState(() {
       _inspectionCount++;
@@ -157,7 +157,7 @@ class _DecisionPanel extends StatelessWidget {
   });
 
   final bool? showKeyboard;
-  final WindowsTextInputDecision? decision;
+  final TextInputDecision? decision;
 
   @override
   Widget build(BuildContext context) {
@@ -228,7 +228,7 @@ class _DecisionPanel extends StatelessWidget {
     );
   }
 
-  static String _description(WindowsTextInputDecision decision) {
+  static String _description(TextInputDecision decision) {
     return switch ((decision.active, decision.secure)) {
       (true, true) => '检测到密码输入控件；不读取任何文本内容',
       (true, false) => '检测到普通可编辑文本控件',

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -136,6 +136,90 @@ class RunnerTests: XCTestCase {
     XCTAssertFalse(flags.contains(.maskControl))
   }
 
+  func testMacTextInputObserverOnlyUsesFocusedElementChanges() {
+    XCTAssertEqual(
+      HardwareSimulatorPlugin.macTextInputNotificationNames,
+      [kAXFocusedUIElementChangedNotification as String]
+    )
+  }
+
+  func testMacTextInputClassifiesEditableAndSecureFields() {
+    let ordinary = HardwareSimulatorPlugin.macTextInputDecision(
+      for: MacOSTextInputTraits(
+        role: kAXTextFieldRole as String,
+        subrole: nil,
+        enabled: true,
+        editable: true,
+        valueSettable: true
+      )
+    )
+    XCTAssertTrue(ordinary.active)
+    XCTAssertEqual(ordinary.secure, false)
+
+    let secure = HardwareSimulatorPlugin.macTextInputDecision(
+      for: MacOSTextInputTraits(
+        role: kAXTextFieldRole as String,
+        subrole: kAXSecureTextFieldSubrole as String,
+        enabled: true,
+        editable: true,
+        valueSettable: false
+      )
+    )
+    XCTAssertTrue(secure.active)
+    XCTAssertEqual(secure.secure, true)
+  }
+
+  func testMacTextInputRejectsDisabledReadOnlyAndNonTextElements() {
+    let disabled = HardwareSimulatorPlugin.macTextInputDecision(
+      for: MacOSTextInputTraits(
+        role: kAXTextAreaRole as String,
+        subrole: nil,
+        enabled: false,
+        editable: true,
+        valueSettable: true
+      )
+    )
+    XCTAssertFalse(disabled.active)
+    XCTAssertNil(disabled.secure)
+
+    let readOnly = HardwareSimulatorPlugin.macTextInputDecision(
+      for: MacOSTextInputTraits(
+        role: kAXTextFieldRole as String,
+        subrole: nil,
+        enabled: true,
+        editable: false,
+        valueSettable: false
+      )
+    )
+    XCTAssertFalse(readOnly.active)
+
+    let button = HardwareSimulatorPlugin.macTextInputDecision(
+      for: MacOSTextInputTraits(
+        role: kAXButtonRole as String,
+        subrole: nil,
+        enabled: true,
+        editable: nil,
+        valueSettable: false
+      )
+    )
+    XCTAssertFalse(button.active)
+  }
+
+  func testMacTextInputValidatesCommittedUnicodeAtomically() {
+    XCTAssertEqual(
+      HardwareSimulatorPlugin.validatedMacOSTextInputCodeUnits("你好 👋"),
+      Array("你好 👋".utf16)
+    )
+    XCTAssertNil(HardwareSimulatorPlugin.validatedMacOSTextInputCodeUnits(""))
+    XCTAssertNil(HardwareSimulatorPlugin.validatedMacOSTextInputCodeUnits("a\nb"))
+    XCTAssertNil(HardwareSimulatorPlugin.validatedMacOSTextInputCodeUnits("\u{7f}"))
+    XCTAssertNil(
+      HardwareSimulatorPlugin.validatedMacOSTextInputCodeUnits(
+        String(repeating: "界", count: 1366)
+      )
+    )
+  }
+
   func testCursorEncodingPrefersImagePointSize() throws {
     let plugin = HardwareSimulatorPlugin()
     let bitmapRep = try XCTUnwrap(NSBitmapImageRep(

--- a/example/test/windows_editing_events_example_test.dart
+++ b/example/test/windows_editing_events_example_test.dart
@@ -53,7 +53,7 @@ Future<void> _sendDecision(Map<String, dynamic> decision) async {
       .handlePlatformMessage(
     'hardware_simulator',
     const StandardMethodCodec().encodeMethodCall(
-      MethodCall('onWindowsTextInputDecision', decision),
+      MethodCall('onTextInputDecision', decision),
     ),
     null,
   );

--- a/lib/hardware_simulator.dart
+++ b/lib/hardware_simulator.dart
@@ -5,9 +5,15 @@ export 'hardware_simulator_platform_interface.dart'
         TrackpadScrollCallback,
         TrackpadScrollEvent,
         TrackpadScrollPhase,
+        TextInputDecision,
+        TextInputDecisionCallback,
         WindowsTextInputDecision,
         WindowsTextInputDecisionCallback;
 import 'display_data.dart';
+
+const bool _macOSDmgDistribution = bool.fromEnvironment(
+  'CLOUDPLAYPLUS_DMG_DISTRIBUTION',
+);
 
 /// Snapshot of the macOS TCC permissions relevant to remote-control hosting.
 class MacOSPermissionStatus {
@@ -19,7 +25,7 @@ class MacOSPermissionStatus {
   /// permission, so it is intentionally not tracked here.)
   final bool inputInjection;
 
-  /// Legacy Accessibility (AXIsProcessTrusted), exposed for diagnostics.
+  /// Accessibility (AXIsProcessTrusted), required for editable-focus events.
   final bool accessibility;
 
   const MacOSPermissionStatus({
@@ -29,7 +35,10 @@ class MacOSPermissionStatus {
   });
 
   /// True when every permission needed to host a session is granted.
-  bool get allGranted => screenCapture && inputInjection;
+  bool get allGranted =>
+      screenCapture &&
+      inputInjection &&
+      (!_macOSDmgDistribution || accessibility);
 
   factory MacOSPermissionStatus.fromMap(Map<String, bool> m) =>
       MacOSPermissionStatus(
@@ -151,8 +160,8 @@ class HardwareSimulator {
   }
 
   /// macOS only. Triggers the consent prompt (or opens System Settings) for
-  /// [type]: `screenCapture` or `inputInjection`. Returns the granted state
-  /// after the request.
+  /// [type]: `screenCapture`, `inputInjection`, or `accessibility`. Returns the
+  /// granted state after the request.
   static Future<bool> requestMacOSPermission(String type) {
     return HardwareSimulatorPlatform.instance.requestMacOSPermission(type);
   }
@@ -274,17 +283,31 @@ class HardwareSimulator {
     HardwareSimulatorPlatform.instance.removeTrackpadScroll(callback);
   }
 
-  /// 注册 Windows 远端点击后的软件盘决策。
+  /// 注册 Host 远端点击后的软件盘决策。
+  static void addTextInputDecision(
+    TextInputDecisionCallback callback,
+  ) {
+    HardwareSimulatorPlatform.instance.addTextInputDecision(callback);
+  }
+
+  static void removeTextInputDecision(
+    TextInputDecisionCallback callback,
+  ) {
+    HardwareSimulatorPlatform.instance.removeTextInputDecision(callback);
+  }
+
+  @Deprecated('Use addTextInputDecision instead.')
   static void addWindowsTextInputDecision(
     WindowsTextInputDecisionCallback callback,
   ) {
-    HardwareSimulatorPlatform.instance.addWindowsTextInputDecision(callback);
+    addTextInputDecision(callback);
   }
 
+  @Deprecated('Use removeTextInputDecision instead.')
   static void removeWindowsTextInputDecision(
     WindowsTextInputDecisionCallback callback,
   ) {
-    HardwareSimulatorPlatform.instance.removeWindowsTextInputDecision(callback);
+    removeTextInputDecision(callback);
   }
 
   // ignore: constant_identifier_names

--- a/lib/hardware_simulator_method_channel.dart
+++ b/lib/hardware_simulator_method_channel.dart
@@ -51,12 +51,13 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
             callback(event);
           }
         }
-      } else if (call.method == "onWindowsTextInputDecision") {
+      } else if (call.method == "onTextInputDecision" ||
+          call.method == "onWindowsTextInputDecision") {
         final arguments = call.arguments;
         if (arguments is Map) {
-          final decision = WindowsTextInputDecision.fromMap(arguments);
-          for (final callback in List<WindowsTextInputDecisionCallback>.of(
-            windowsTextInputDecisionCallbacks,
+          final decision = TextInputDecision.fromMap(arguments);
+          for (final callback in List<TextInputDecisionCallback>.of(
+            textInputDecisionCallbacks,
           )) {
             callback(decision);
           }
@@ -311,48 +312,59 @@ class MethodChannelHardwareSimulator extends HardwareSimulatorPlatform {
     }
   }
 
-  final List<WindowsTextInputDecisionCallback>
-      windowsTextInputDecisionCallbacks = [];
+  final List<TextInputDecisionCallback> textInputDecisionCallbacks = [];
 
   @override
-  void addWindowsTextInputDecision(WindowsTextInputDecisionCallback callback) {
+  void addTextInputDecision(TextInputDecisionCallback callback) {
     if (!isinitialized) init();
-    if (windowsTextInputDecisionCallbacks.contains(callback)) return;
-    final shouldStartCapture = windowsTextInputDecisionCallbacks.isEmpty;
-    windowsTextInputDecisionCallbacks.add(callback);
+    if (textInputDecisionCallbacks.contains(callback)) return;
+    final shouldStartCapture = textInputDecisionCallbacks.isEmpty;
+    textInputDecisionCallbacks.add(callback);
     if (shouldStartCapture) {
-      unawaited(startWindowsTextInputDecisionCapture());
+      unawaited(startTextInputDecisionCapture());
     }
   }
 
   @override
-  void removeWindowsTextInputDecision(
-    WindowsTextInputDecisionCallback callback,
+  void removeTextInputDecision(
+    TextInputDecisionCallback callback,
   ) {
-    final removed = windowsTextInputDecisionCallbacks.remove(callback);
-    if (removed && windowsTextInputDecisionCallbacks.isEmpty) {
-      unawaited(stopWindowsTextInputDecisionCapture());
+    final removed = textInputDecisionCallbacks.remove(callback);
+    if (removed && textInputDecisionCallbacks.isEmpty) {
+      unawaited(stopTextInputDecisionCapture());
     }
   }
 
   @override
-  Future<bool> startWindowsTextInputDecisionCapture() async {
+  Future<bool> startTextInputDecisionCapture() async {
     try {
       final supported = await methodChannel
-          .invokeMethod<Object?>('startWindowsTextInputDecisionCapture');
+          .invokeMethod<Object?>('startTextInputDecisionCapture');
       return supported == true;
     } on MissingPluginException {
-      return false;
+      try {
+        final supported = await methodChannel.invokeMethod<Object?>(
+          'startWindowsTextInputDecisionCapture',
+        );
+        return supported == true;
+      } on MissingPluginException {
+        return false;
+      }
     }
   }
 
   @override
-  Future<void> stopWindowsTextInputDecisionCapture() async {
+  Future<void> stopTextInputDecisionCapture() async {
     try {
-      await methodChannel
-          .invokeMethod<void>('stopWindowsTextInputDecisionCapture');
+      await methodChannel.invokeMethod<void>('stopTextInputDecisionCapture');
     } on MissingPluginException {
-      return;
+      try {
+        await methodChannel.invokeMethod<void>(
+          'stopWindowsTextInputDecisionCapture',
+        );
+      } on MissingPluginException {
+        return;
+      }
     }
   }
 

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -248,44 +248,44 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   /// 注册 Host 远端点击后的文本输入决策。
   void addTextInputDecision(
     TextInputDecisionCallback callback,
-  ) {}
+  ) {
+    addWindowsTextInputDecision(callback);
+  }
 
   /// 移除 Host 软件盘决策监听器。
   void removeTextInputDecision(
     TextInputDecisionCallback callback,
-  ) {}
+  ) {
+    removeWindowsTextInputDecision(callback);
+  }
 
   /// 启动原生编辑焦点检测；不支持的平台返回 false。
-  Future<bool> startTextInputDecisionCapture() async {
-    return false;
+  Future<bool> startTextInputDecisionCapture() {
+    return startWindowsTextInputDecisionCapture();
   }
 
   /// 停止原生编辑焦点检测。
-  Future<void> stopTextInputDecisionCapture() async {}
+  Future<void> stopTextInputDecisionCapture() {
+    return stopWindowsTextInputDecisionCapture();
+  }
 
   @Deprecated('Use addTextInputDecision instead.')
   void addWindowsTextInputDecision(
     WindowsTextInputDecisionCallback callback,
-  ) {
-    addTextInputDecision(callback);
-  }
+  ) {}
 
   @Deprecated('Use removeTextInputDecision instead.')
   void removeWindowsTextInputDecision(
     WindowsTextInputDecisionCallback callback,
-  ) {
-    removeTextInputDecision(callback);
-  }
+  ) {}
 
   @Deprecated('Use startTextInputDecisionCapture instead.')
-  Future<bool> startWindowsTextInputDecisionCapture() {
-    return startTextInputDecisionCapture();
+  Future<bool> startWindowsTextInputDecisionCapture() async {
+    return false;
   }
 
   @Deprecated('Use stopTextInputDecisionCapture instead.')
-  Future<void> stopWindowsTextInputDecisionCapture() {
-    return stopTextInputDecisionCapture();
-  }
+  Future<void> stopWindowsTextInputDecisionCapture() async {}
 
   void addCursorImageUpdated(
       CursorImageUpdatedCallback callback, int callbackId, bool hookAll) {

--- a/lib/hardware_simulator_platform_interface.dart
+++ b/lib/hardware_simulator_platform_interface.dart
@@ -12,9 +12,11 @@ typedef KeyboardPressedCallback = void Function(int button, bool isDown);
 typedef KeyBlockedCallback = void Function(int keyCode, bool isDown);
 typedef CursorWheelCallback = void Function(double deltaX, double deltaY);
 typedef TrackpadScrollCallback = void Function(TrackpadScrollEvent event);
-typedef WindowsTextInputDecisionCallback = void Function(
-  WindowsTextInputDecision decision,
+typedef TextInputDecisionCallback = void Function(
+  TextInputDecision decision,
 );
+@Deprecated('Use TextInputDecisionCallback instead.')
+typedef WindowsTextInputDecisionCallback = TextInputDecisionCallback;
 typedef CursorImageUpdatedCallback = void Function(
     int message, int messageInfo, Uint8List cursorImage);
 typedef CursorPositionUpdatedCallback = void Function(
@@ -58,23 +60,23 @@ class TrackpadScrollEvent {
   final bool isMomentum;
 }
 
-/// 远端主鼠标、触摸或笔抬起后，Windows UI Automation 给出的软件盘决策。
+/// 远端主鼠标、触摸或笔抬起后，Host 原生可访问性 API 给出的软件盘决策。
 ///
 /// [active] 为 true 时应弹出软件盘，否则应收起。[secure] 只在 UIA 明确判断
 /// 当前可编辑控件是否为密码框时取 true 或 false；无法确认或 [active] 为 false
 /// 时为 null。[editFocusRequestId] 原样返回触发检查的 Dart 请求标识。
 @immutable
-class WindowsTextInputDecision {
-  const WindowsTextInputDecision({
+class TextInputDecision {
+  const TextInputDecision({
     required this.active,
     required this.secure,
     this.editFocusRequestId,
   });
 
-  factory WindowsTextInputDecision.fromMap(Map<Object?, Object?> map) {
+  factory TextInputDecision.fromMap(Map<Object?, Object?> map) {
     final active = map['active'] == true;
     final secure = map['secure'];
-    return WindowsTextInputDecision(
+    return TextInputDecision(
       active: active,
       secure: active && secure is bool ? secure : null,
       editFocusRequestId: map['editFocusRequestId'] is int
@@ -87,6 +89,9 @@ class WindowsTextInputDecision {
   final bool? secure;
   final int? editFocusRequestId;
 }
+
+@Deprecated('Use TextInputDecision instead.')
+typedef WindowsTextInputDecision = TextInputDecision;
 
 abstract class HardwareSimulatorPlatform extends PlatformInterface {
   /// Constructs a HardwareSimulatorPlatform.
@@ -121,8 +126,9 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   }
 
   /// macOS only. Asks macOS to show the consent prompt for [type]
-  /// (`screenCapture` or `inputInjection`), opening System Settings if no
-  /// auto-prompt is available. Returns the granted state after the request.
+  /// (`screenCapture`, `inputInjection`, or `accessibility`), opening System
+  /// Settings if no auto-prompt is available. Returns the granted state after
+  /// the request.
   Future<bool> requestMacOSPermission(String type) async {
     return false;
   }
@@ -239,23 +245,47 @@ abstract class HardwareSimulatorPlatform extends PlatformInterface {
   /// Stops native precision trackpad capture when implemented.
   Future<void> stopTrackpadScrollCapture() async {}
 
-  /// 注册 Windows 远端点击后的文本输入决策。
-  void addWindowsTextInputDecision(
-    WindowsTextInputDecisionCallback callback,
+  /// 注册 Host 远端点击后的文本输入决策。
+  void addTextInputDecision(
+    TextInputDecisionCallback callback,
   ) {}
 
-  /// 移除 Windows 软件盘决策监听器。
-  void removeWindowsTextInputDecision(
-    WindowsTextInputDecisionCallback callback,
+  /// 移除 Host 软件盘决策监听器。
+  void removeTextInputDecision(
+    TextInputDecisionCallback callback,
   ) {}
 
-  /// 启动 Windows 按需 UI Automation 检查；不支持的平台返回 false。
-  Future<bool> startWindowsTextInputDecisionCapture() async {
+  /// 启动原生编辑焦点检测；不支持的平台返回 false。
+  Future<bool> startTextInputDecisionCapture() async {
     return false;
   }
 
-  /// 停止 Windows 按需 UI Automation 检查。
-  Future<void> stopWindowsTextInputDecisionCapture() async {}
+  /// 停止原生编辑焦点检测。
+  Future<void> stopTextInputDecisionCapture() async {}
+
+  @Deprecated('Use addTextInputDecision instead.')
+  void addWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    addTextInputDecision(callback);
+  }
+
+  @Deprecated('Use removeTextInputDecision instead.')
+  void removeWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    removeTextInputDecision(callback);
+  }
+
+  @Deprecated('Use startTextInputDecisionCapture instead.')
+  Future<bool> startWindowsTextInputDecisionCapture() {
+    return startTextInputDecisionCapture();
+  }
+
+  @Deprecated('Use stopTextInputDecisionCapture instead.')
+  Future<void> stopWindowsTextInputDecisionCapture() {
+    return stopTextInputDecisionCapture();
+  }
 
   void addCursorImageUpdated(
       CursorImageUpdatedCallback callback, int callbackId, bool hookAll) {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -13,6 +13,19 @@ class CursorConstants {
   static let cursorPositionChanged = 6
 }
 
+struct MacOSTextInputTraits {
+  let role: String?
+  let subrole: String?
+  let enabled: Bool
+  let editable: Bool?
+  let valueSettable: Bool
+}
+
+struct MacOSTextInputDecision: Equatable {
+  let active: Bool
+  let secure: Bool?
+}
+
 public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var methodChannel: FlutterMethodChannel?
   private weak var registrar: FlutterPluginRegistrar?
@@ -35,6 +48,21 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   private var activeKeyRepeatTimer: DispatchSourceTimer?
   private var activeRepeatingWindowsKeyCode: Int?
   private var activeKeyMacCodes: [Int: CGKeyCode] = [:]
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private let macTextInputQueue = DispatchQueue(
+    label: "com.cloudplayplus.hardware-simulator.text-input"
+  )
+  private var macTextInputObserver: AXObserver?
+  private var macTextInputObservedApplication: AXUIElement?
+  private var macTextInputWorkspaceObserver: NSObjectProtocol?
+  private var macTextInputCaptureStarted = false
+  private var macTextInputSnapshot = MacOSTextInputDecision(
+    active: false,
+    secure: nil
+  )
+  private var macTextInputSnapshotKnown = false
+  private var macTextInputRequestSequence: UInt64 = 0
+#endif
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   private let macVirtualDisplayQueueKey = DispatchSpecificKey<Void>()
   private let macVirtualDisplayQueue = DispatchQueue(
@@ -70,6 +98,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   deinit {
     stopTrackpadScrollCapture()
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    stopMacOSTextInputDecisionCapture()
+#endif
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
     if let macTerminationObserver {
       NotificationCenter.default.removeObserver(macTerminationObserver)
@@ -2584,6 +2615,520 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   
   var activities: [String: NSObjectProtocol] = [:]
 
+  // MARK: - macOS editable-focus observation and committed text
+
+  static let macTextInputNotificationNames = [
+    kAXFocusedUIElementChangedNotification as String
+  ]
+
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private static let macTextInputObserverCallback: AXObserverCallback = {
+    _, element, notification, refcon in
+    guard
+      notification as String == kAXFocusedUIElementChangedNotification as String,
+      let refcon
+    else {
+      return
+    }
+    let plugin = Unmanaged<HardwareSimulatorPlugin>
+      .fromOpaque(refcon)
+      .takeUnretainedValue()
+    plugin.updateMacTextInputSnapshot(from: element)
+  }
+#endif
+
+  static func macTextInputDecision(
+    for traits: MacOSTextInputTraits
+  ) -> MacOSTextInputDecision {
+    guard traits.enabled, traits.editable != false else {
+      return MacOSTextInputDecision(active: false, secure: nil)
+    }
+    let secure = traits.subrole == kAXSecureTextFieldSubrole as String
+    let knownTextRole = traits.role == kAXTextFieldRole as String
+      || traits.role == kAXTextAreaRole as String
+      || traits.role == kAXComboBoxRole as String
+    let active = secure
+      || traits.editable == true
+      || (knownTextRole && traits.valueSettable)
+    return MacOSTextInputDecision(
+      active: active,
+      secure: active ? secure : nil
+    )
+  }
+
+  static func validatedMacOSTextInputCodeUnits(
+    _ text: String
+  ) -> [UniChar]? {
+    guard !text.isEmpty, text.utf8.count <= 4096 else { return nil }
+    for scalar in text.unicodeScalars {
+      if scalar.value <= 0x1f || scalar.value == 0x7f {
+        return nil
+      }
+    }
+    let codeUnits = Array(text.utf16)
+    return codeUnits.isEmpty ? nil : codeUnits
+  }
+
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private static func macAXString(
+    _ element: AXUIElement,
+    attribute: String
+  ) -> String? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+      element,
+      attribute as CFString,
+      &value
+    ) == .success else {
+      return nil
+    }
+    return value as? String
+  }
+
+  private static func macAXBool(
+    _ element: AXUIElement,
+    attribute: String
+  ) -> Bool? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+      element,
+      attribute as CFString,
+      &value
+    ) == .success else {
+      return nil
+    }
+    return value as? Bool
+  }
+
+  private static func macAXElement(
+    _ element: AXUIElement,
+    attribute: String
+  ) -> AXUIElement? {
+    var value: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(
+        element,
+        attribute as CFString,
+        &value
+      ) == .success,
+      let value,
+      CFGetTypeID(value) == AXUIElementGetTypeID()
+    else {
+      return nil
+    }
+    return (value as! AXUIElement)
+  }
+
+  private static func macAXPoint(
+    _ element: AXUIElement,
+    attribute: String
+  ) -> CGPoint? {
+    var value: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(
+        element,
+        attribute as CFString,
+        &value
+      ) == .success,
+      let value,
+      CFGetTypeID(value) == AXValueGetTypeID()
+    else {
+      return nil
+    }
+    let axValue = value as! AXValue
+    guard AXValueGetType(axValue) == .cgPoint else { return nil }
+    var point = CGPoint.zero
+    return AXValueGetValue(axValue, .cgPoint, &point) ? point : nil
+  }
+
+  private static func macAXSize(
+    _ element: AXUIElement,
+    attribute: String
+  ) -> CGSize? {
+    var value: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(
+        element,
+        attribute as CFString,
+        &value
+      ) == .success,
+      let value,
+      CFGetTypeID(value) == AXValueGetTypeID()
+    else {
+      return nil
+    }
+    let axValue = value as! AXValue
+    guard AXValueGetType(axValue) == .cgSize else { return nil }
+    var size = CGSize.zero
+    return AXValueGetValue(axValue, .cgSize, &size) ? size : nil
+  }
+
+  private static func macAXFrame(_ element: AXUIElement) -> CGRect? {
+    guard
+      let position = macAXPoint(
+        element,
+        attribute: kAXPositionAttribute as String
+      ),
+      let size = macAXSize(
+        element,
+        attribute: kAXSizeAttribute as String
+      ),
+      size.width > 0,
+      size.height > 0
+    else {
+      return nil
+    }
+    return CGRect(origin: position, size: size)
+  }
+
+  private static func macAXAttributeIsSettable(
+    _ element: AXUIElement,
+    attribute: String
+  ) -> Bool {
+    var settable = DarwinBoolean(false)
+    return AXUIElementIsAttributeSettable(
+      element,
+      attribute as CFString,
+      &settable
+    ) == .success && settable.boolValue
+  }
+
+  private static func macTextInputTraits(
+    for element: AXUIElement
+  ) -> MacOSTextInputTraits {
+    let valueSettable = macAXAttributeIsSettable(
+      element,
+      attribute: kAXValueAttribute as String
+    ) || macAXAttributeIsSettable(
+      element,
+      attribute: kAXSelectedTextAttribute as String
+    ) || macAXAttributeIsSettable(
+      element,
+      attribute: kAXSelectedTextRangeAttribute as String
+    )
+    return MacOSTextInputTraits(
+      role: macAXString(element, attribute: kAXRoleAttribute as String),
+      subrole: macAXString(element, attribute: kAXSubroleAttribute as String),
+      enabled: macAXBool(
+        element,
+        attribute: kAXEnabledAttribute as String
+      ) ?? true,
+      editable: macAXBool(
+        element,
+        attribute: kAXIsEditableAttribute as String
+      ),
+      valueSettable: valueSettable
+    )
+  }
+
+  private static func inspectMacTextInputElement(
+    _ element: AXUIElement,
+    includeParentChain: Bool = false
+  ) -> MacOSTextInputDecision {
+    var candidates = [AXUIElement]()
+    func appendUnique(_ candidate: AXUIElement) {
+      if !candidates.contains(where: { CFEqual($0, candidate) }) {
+        candidates.append(candidate)
+      }
+    }
+
+    appendUnique(element)
+    if let editableAncestor = macAXElement(
+      element,
+      attribute: kAXEditableAncestorAttribute as String
+    ) {
+      appendUnique(editableAncestor)
+    }
+    if let highestEditableAncestor = macAXElement(
+      element,
+      attribute: kAXHighestEditableAncestorAttribute as String
+    ) {
+      appendUnique(highestEditableAncestor)
+    }
+    if includeParentChain {
+      var ancestor = element
+      for _ in 0..<12 {
+        guard let parent = macAXElement(
+          ancestor,
+          attribute: kAXParentAttribute as String
+        ) else {
+          break
+        }
+        appendUnique(parent)
+        ancestor = parent
+      }
+    }
+    for candidate in candidates {
+      let decision = macTextInputDecision(
+        for: macTextInputTraits(for: candidate)
+      )
+      if decision.active {
+        return decision
+      }
+    }
+    return MacOSTextInputDecision(active: false, secure: nil)
+  }
+
+  private static func inspectMacFocusedElement(
+    _ application: AXUIElement
+  ) -> MacOSTextInputDecision? {
+    guard let focused = macAXElement(
+      application,
+      attribute: kAXFocusedUIElementAttribute as String
+    ) else {
+      return nil
+    }
+    return inspectMacTextInputElement(focused)
+  }
+
+  private static func inspectMacTextInputAtPosition(
+    _ location: CGPoint,
+    application: AXUIElement?
+  ) -> MacOSTextInputDecision {
+    let systemWide = AXUIElementCreateSystemWide()
+    var hitElement: AXUIElement?
+    if AXUIElementCopyElementAtPosition(
+      systemWide,
+      Float(location.x),
+      Float(location.y),
+      &hitElement
+    ) == .success, let hitElement {
+      let hitDecision = inspectMacTextInputElement(
+        hitElement,
+        includeParentChain: true
+      )
+      if hitDecision.active {
+        return hitDecision
+      }
+    }
+
+    // Browser accessibility providers sometimes expose the editable object as
+    // the focused element but return a generic WebArea descendant for hit-test.
+    // The frame check keeps an app-activation focus restore from opening the
+    // keyboard when the remote click landed somewhere else.
+    guard
+      let application,
+      let focused = macAXElement(
+        application,
+        attribute: kAXFocusedUIElementAttribute as String
+      ),
+      let frame = macAXFrame(focused),
+      frame.contains(location)
+    else {
+      return MacOSTextInputDecision(active: false, secure: nil)
+    }
+    return inspectMacTextInputElement(focused, includeParentChain: true)
+  }
+
+  private func updateMacTextInputSnapshot(from element: AXUIElement) {
+    macTextInputQueue.async { [weak self] in
+      guard let self else { return }
+      self.macTextInputSnapshot = Self.inspectMacTextInputElement(element)
+      self.macTextInputSnapshotKnown = true
+    }
+  }
+
+  private func refreshMacTextInputSnapshot(
+    from application: AXUIElement
+  ) {
+    macTextInputQueue.async { [weak self] in
+      guard let self else { return }
+      if let decision = Self.inspectMacFocusedElement(application) {
+        self.macTextInputSnapshot = decision
+        self.macTextInputSnapshotKnown = true
+      } else {
+        self.macTextInputSnapshot = MacOSTextInputDecision(
+          active: false,
+          secure: nil
+        )
+        self.macTextInputSnapshotKnown = false
+      }
+    }
+  }
+
+  private func detachMacTextInputObserver() {
+    if let observer = macTextInputObserver,
+       let application = macTextInputObservedApplication {
+      AXObserverRemoveNotification(
+        observer,
+        application,
+        kAXFocusedUIElementChangedNotification as CFString
+      )
+      CFRunLoopRemoveSource(
+        CFRunLoopGetMain(),
+        AXObserverGetRunLoopSource(observer),
+        .commonModes
+      )
+    }
+    macTextInputObserver = nil
+    macTextInputObservedApplication = nil
+  }
+
+  private func attachMacTextInputObserver(
+    to runningApplication: NSRunningApplication
+  ) {
+    detachMacTextInputObserver()
+
+    let application = AXUIElementCreateApplication(
+      runningApplication.processIdentifier
+    )
+    AXUIElementSetMessagingTimeout(application, 0.2)
+    var observer: AXObserver?
+    guard AXObserverCreate(
+      runningApplication.processIdentifier,
+      Self.macTextInputObserverCallback,
+      &observer
+    ) == .success, let observer else {
+      return
+    }
+    let refcon = Unmanaged.passUnretained(self).toOpaque()
+    guard AXObserverAddNotification(
+      observer,
+      application,
+      kAXFocusedUIElementChangedNotification as CFString,
+      refcon
+    ) == .success else {
+      return
+    }
+
+    macTextInputObserver = observer
+    macTextInputObservedApplication = application
+    CFRunLoopAddSource(
+      CFRunLoopGetMain(),
+      AXObserverGetRunLoopSource(observer),
+      .commonModes
+    )
+    refreshMacTextInputSnapshot(from: application)
+  }
+
+  private func startMacOSTextInputDecisionCapture() -> Bool {
+    if macTextInputCaptureStarted { return true }
+    guard AXIsProcessTrusted() else { return false }
+    macTextInputCaptureStarted = true
+    macTextInputWorkspaceObserver = NSWorkspace.shared.notificationCenter
+      .addObserver(
+        forName: NSWorkspace.didActivateApplicationNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] notification in
+        guard
+          let self,
+          let application = notification.userInfo?[
+            NSWorkspace.applicationUserInfoKey
+          ] as? NSRunningApplication
+        else {
+          return
+        }
+        self.attachMacTextInputObserver(to: application)
+      }
+    if let application = NSWorkspace.shared.frontmostApplication {
+      attachMacTextInputObserver(to: application)
+    }
+    return true
+  }
+
+  private func stopMacOSTextInputDecisionCapture() {
+    guard macTextInputCaptureStarted else { return }
+    macTextInputCaptureStarted = false
+    if let macTextInputWorkspaceObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(
+        macTextInputWorkspaceObserver
+      )
+    }
+    macTextInputWorkspaceObserver = nil
+    detachMacTextInputObserver()
+    macTextInputQueue.async { [weak self] in
+      guard let self else { return }
+      self.macTextInputRequestSequence &+= 1
+      self.macTextInputSnapshot = MacOSTextInputDecision(
+        active: false,
+        secure: nil
+      )
+      self.macTextInputSnapshotKnown = false
+    }
+  }
+
+  private func inspectMacTextInputAfterRemotePointerUp(
+    editFocusRequestId: Int?,
+    location: CGPoint?
+  ) {
+    guard
+      macTextInputCaptureStarted,
+      let editFocusRequestId,
+      let location
+    else {
+      return
+    }
+    let observedApplication = macTextInputObservedApplication
+    macTextInputQueue.async { [weak self] in
+      guard let self else { return }
+      self.macTextInputRequestSequence &+= 1
+      let sequence = self.macTextInputRequestSequence
+      self.macTextInputQueue.asyncAfter(
+        deadline: .now() + .milliseconds(50)
+      ) { [weak self] in
+        guard
+          let self,
+          sequence == self.macTextInputRequestSequence
+        else {
+          return
+        }
+        let decision = Self.inspectMacTextInputAtPosition(
+          location,
+          application: observedApplication
+        )
+        self.macTextInputSnapshot = decision
+        self.macTextInputSnapshotKnown = true
+        DispatchQueue.main.async { [weak self] in
+          self?.methodChannel?.invokeMethod(
+            "onTextInputDecision",
+            arguments: [
+              "active": decision.active,
+              "secure": decision.secure as Any,
+              "editFocusRequestId": editFocusRequestId,
+            ]
+          )
+        }
+      }
+    }
+  }
+
+  private func performMacOSTextInput(_ text: String) -> Bool {
+    guard let codeUnits = Self.validatedMacOSTextInputCodeUnits(text) else {
+      return false
+    }
+    guard
+      let keyDown = CGEvent(
+        keyboardEventSource: nil,
+        virtualKey: 0,
+        keyDown: true
+      ),
+      let keyUp = CGEvent(
+        keyboardEventSource: nil,
+        virtualKey: 0,
+        keyDown: false
+      )
+    else {
+      return false
+    }
+    codeUnits.withUnsafeBufferPointer { buffer in
+      keyDown.keyboardSetUnicodeString(
+        stringLength: buffer.count,
+        unicodeString: buffer.baseAddress
+      )
+      keyUp.keyboardSetUnicodeString(
+        stringLength: buffer.count,
+        unicodeString: buffer.baseAddress
+      )
+    }
+    keyDown.flags = []
+    keyUp.flags = []
+    keyDown.post(tap: .cghidEventTap)
+    keyUp.post(tap: .cghidEventTap)
+    return true
+  }
+#endif
+
   // MARK: - macOS permission self-check
 
   /// Whether this process can capture the screen. Uses the official preflight
@@ -2618,7 +3163,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   /// NOTE: both calls cache in-process, so a freshly-granted permission only
   /// shows up after relaunch. The UI tells the user this after they request it.
   private func macInputInjectionGranted() -> Bool {
-    return CGPreflightPostEventAccess() || AXIsProcessTrusted()
+    if #available(macOS 10.15, *) {
+      return CGPreflightPostEventAccess() || AXIsProcessTrusted()
+    }
+    return AXIsProcessTrusted()
   }
 
   /// Opens the relevant pane of System Settings → Privacy & Security.
@@ -2639,6 +3187,17 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     switch call.method {
     case "getPlatformVersion":
       result("macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
+    case "startTextInputDecisionCapture":
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+      result(startMacOSTextInputDecisionCapture())
+#else
+      result(false)
+#endif
+    case "stopTextInputDecisionCapture":
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+      stopMacOSTextInputDecisionCapture()
+#endif
+      result(nil)
     case "startTrackpadScrollCapture":
       result(startTrackpadScrollCapture())
     case "stopTrackpadScrollCapture":
@@ -2648,7 +3207,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       // Reports the *current process's* live TCC status. Does NOT prompt.
       // - screenCapture: needed to grab the screen (ScreenCaptureKit / CGDisplayStream)
       // - inputInjection: needed to post synthetic mouse clicks / key events (CGEventPost)
-      // - accessibility: legacy AX trust, kept for diagnostics
+      // - accessibility: AX trust for editable-focus observation
       result([
         "screenCapture": macScreenCaptureGranted(),
         "inputInjection": macInputInjectionGranted(),
@@ -2673,9 +3232,19 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         }
       case "inputInjection":
         // CGRequestPostEventAccess shows the prompt the first time (macOS 10.15+).
-        let granted = CGRequestPostEventAccess()
-        if !granted { openMacOSPrivacySettings(section: "accessibility") }
-        result(granted)
+        if #available(macOS 10.15, *) {
+          let granted = CGRequestPostEventAccess()
+          if !granted { openMacOSPrivacySettings(section: "accessibility") }
+          result(granted)
+        } else {
+          openMacOSPrivacySettings(section: "accessibility")
+          result(AXIsProcessTrusted())
+        }
+      case "accessibility":
+        let options = [
+          kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+        ] as CFDictionary
+        result(AXIsProcessTrustedWithOptions(options))
       default:
         result(FlutterError(code: "BAD_ARGS", message: "Unknown permission type: \(type)", details: nil))
       }
@@ -2896,7 +3465,16 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         let buttonId = args["buttonId"] as? Int,
         let isDown = args["isDown"] as? Bool {
         // 调用鼠标移动函数
+        let pointerLocation = currentMouseLocation()
         performMouseButton(buttonId: buttonId, isDown: isDown)
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+        if buttonId == 1 && !isDown {
+          inspectMacTextInputAfterRemotePointerUp(
+            editFocusRequestId: args["editFocusRequestId"] as? Int,
+            location: pointerLocation
+          )
+        }
+#endif
         result(nil) // 表示成功执行，不返回值
       } else {
         result(FlutterError(code: "BAD_ARGS", message: "Missing or incorrect arguments for Mouse Press", details: nil))
@@ -2947,6 +3525,31 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
       } else {
         result(FlutterError(code: "BAD_ARGS", message: "Missing or incorrect arguments for KeyPress", details: nil))
       }
+    case "performTextInput":
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+      guard
+        let args = call.arguments as? [String: Any],
+        let text = args["text"] as? String
+      else {
+        result(FlutterError(
+          code: "INVALID_TEXT",
+          message: "Text input must be a string",
+          details: nil
+        ))
+        return
+      }
+      if performMacOSTextInput(text) {
+        result(nil)
+      } else {
+        result(FlutterError(
+          code: "INVALID_TEXT",
+          message: "Text input is invalid or too long",
+          details: nil
+        ))
+      }
+#else
+      result(FlutterMethodNotImplemented)
+#endif
     case "clearAllPressedEvents":
       keyboardRepeatQueue.async { [weak self] in
         self?.clearAllPressedEventsOnKeyboardQueue()

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -2882,8 +2882,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   }
 
   private static func inspectMacTextInputAtPosition(
-    _ location: CGPoint,
-    application: AXUIElement?
+    _ location: CGPoint
   ) -> MacOSTextInputDecision {
     let systemWide = AXUIElementCreateSystemWide()
     var hitElement: AXUIElement?
@@ -2907,7 +2906,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     // The frame check keeps an app-activation focus restore from opening the
     // keyboard when the remote click landed somewhere else.
     guard
-      let application,
+      let application = macAXElement(
+        systemWide,
+        attribute: kAXFocusedApplicationAttribute as String
+      ),
       let focused = macAXElement(
         application,
         attribute: kAXFocusedUIElementAttribute as String
@@ -3059,7 +3061,6 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     else {
       return
     }
-    let observedApplication = macTextInputObservedApplication
     macTextInputQueue.async { [weak self] in
       guard let self else { return }
       self.macTextInputRequestSequence &+= 1
@@ -3073,10 +3074,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
         else {
           return
         }
-        let decision = Self.inspectMacTextInputAtPosition(
-          location,
-          application: observedApplication
-        )
+        let decision = Self.inspectMacTextInputAtPosition(location)
         self.macTextInputSnapshot = decision
         self.macTextInputSnapshotKnown = true
         DispatchQueue.main.async { [weak self] in

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -286,57 +286,56 @@ void main() {
     await Future<void>.delayed(Duration.zero);
   });
 
-  test('first and last Windows text input listeners manage native capture',
-      () async {
+  test('first and last text input listeners manage native capture', () async {
     final calls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
         calls.add(methodCall);
-        return methodCall.method == 'startWindowsTextInputDecisionCapture';
+        return methodCall.method == 'startTextInputDecisionCapture';
       },
     );
 
-    void firstListener(WindowsTextInputDecision _) {}
-    void secondListener(WindowsTextInputDecision _) {}
-    platform.addWindowsTextInputDecision(firstListener);
-    platform.addWindowsTextInputDecision(firstListener);
-    platform.addWindowsTextInputDecision(secondListener);
+    void firstListener(TextInputDecision _) {}
+    void secondListener(TextInputDecision _) {}
+    platform.addTextInputDecision(firstListener);
+    platform.addTextInputDecision(firstListener);
+    platform.addTextInputDecision(secondListener);
     await Future<void>.delayed(Duration.zero);
 
-    platform.removeWindowsTextInputDecision(firstListener);
+    platform.removeTextInputDecision(firstListener);
     await Future<void>.delayed(Duration.zero);
     expect(
       calls.map((call) => call.method),
-      ['startWindowsTextInputDecisionCapture'],
+      ['startTextInputDecisionCapture'],
     );
 
-    platform.removeWindowsTextInputDecision(secondListener);
+    platform.removeTextInputDecision(secondListener);
     await Future<void>.delayed(Duration.zero);
     expect(
       calls.map((call) => call.method),
       [
-        'startWindowsTextInputDecisionCapture',
-        'stopWindowsTextInputDecisionCapture',
+        'startTextInputDecisionCapture',
+        'stopTextInputDecisionCapture',
       ],
     );
   });
 
-  test('decodes minimal Windows text input decisions', () async {
-    WindowsTextInputDecision? received;
-    late WindowsTextInputDecisionCallback listener;
+  test('decodes minimal text input decisions', () async {
+    TextInputDecision? received;
+    late TextInputDecisionCallback listener;
     listener = (decision) {
       received = decision;
-      platform.removeWindowsTextInputDecision(listener);
+      platform.removeTextInputDecision(listener);
     };
-    platform.addWindowsTextInputDecision(listener);
+    platform.addTextInputDecision(listener);
 
     await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage(
       'hardware_simulator',
       const StandardMethodCodec().encodeMethodCall(
-        const MethodCall('onWindowsTextInputDecision', <String, dynamic>{
+        const MethodCall('onTextInputDecision', <String, dynamic>{
           'active': true,
           'secure': false,
           'editFocusRequestId': 42,
@@ -354,11 +353,11 @@ void main() {
 
   test('normalizes unknown and inactive secure state to null', () {
     expect(
-      WindowsTextInputDecision.fromMap(const {'active': true}).secure,
+      TextInputDecision.fromMap(const {'active': true}).secure,
       isNull,
     );
     expect(
-      WindowsTextInputDecision.fromMap(
+      TextInputDecision.fromMap(
         const {'active': false, 'secure': true},
       ).secure,
       isNull,

--- a/test/hardware_simulator_method_channel_test.dart
+++ b/test/hardware_simulator_method_channel_test.dart
@@ -2,6 +2,39 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hardware_simulator/hardware_simulator.dart';
 import 'package:hardware_simulator/hardware_simulator_method_channel.dart';
+import 'package:hardware_simulator/hardware_simulator_platform_interface.dart';
+
+class _LegacyWindowsTextInputPlatform extends HardwareSimulatorPlatform {
+  int listenerAdds = 0;
+  int listenerRemoves = 0;
+  int captureStarts = 0;
+  int captureStops = 0;
+
+  @override
+  void addWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    listenerAdds += 1;
+  }
+
+  @override
+  void removeWindowsTextInputDecision(
+    WindowsTextInputDecisionCallback callback,
+  ) {
+    listenerRemoves += 1;
+  }
+
+  @override
+  Future<bool> startWindowsTextInputDecisionCapture() async {
+    captureStarts += 1;
+    return true;
+  }
+
+  @override
+  Future<void> stopWindowsTextInputDecisionCapture() async {
+    captureStops += 1;
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -26,6 +59,22 @@ void main() {
 
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
+  });
+
+  test('unified text input API delegates to legacy Windows overrides',
+      () async {
+    final legacy = _LegacyWindowsTextInputPlatform();
+    void listener(TextInputDecision _) {}
+
+    legacy.addTextInputDecision(listener);
+    legacy.removeTextInputDecision(listener);
+
+    expect(await legacy.startTextInputDecisionCapture(), isTrue);
+    await legacy.stopTextInputDecisionCapture();
+    expect(legacy.listenerAdds, 1);
+    expect(legacy.listenerRemoves, 1);
+    expect(legacy.captureStarts, 1);
+    expect(legacy.captureStops, 1);
   });
 
   test('performTextInput sends committed text without transformation',

--- a/windows/hardware_simulator_plugin.cpp
+++ b/windows/hardware_simulator_plugin.cpp
@@ -1210,7 +1210,7 @@ void HardwareSimulatorPlugin::SendWindowsTextInputDecision(
           ? flutter::EncodableValue(decision.edit_focus_request_id.value())
           : flutter::EncodableValue();
   channel_->InvokeMethod(
-      "onWindowsTextInputDecision",
+      "onTextInputDecision",
       std::make_unique<flutter::EncodableValue>(message));
 }
 
@@ -1606,10 +1606,14 @@ void HardwareSimulatorPlugin::HandleMethodCall(
     }
     result->Success(flutter::EncodableValue(version_stream.str()));
   } else if (method_call.method_name().compare(
+                 "startTextInputDecisionCapture") == 0 ||
+             method_call.method_name().compare(
                  "startWindowsTextInputDecisionCapture") == 0) {
     result->Success(
         flutter::EncodableValue(StartWindowsEditingEventMonitor()));
   } else if (method_call.method_name().compare(
+                 "stopTextInputDecisionCapture") == 0 ||
+             method_call.method_name().compare(
                  "stopWindowsTextInputDecisionCapture") == 0) {
     StopWindowsEditingEventMonitor();
     result->Success(nullptr);


### PR DESCRIPTION
## Summary

- add DMG-only macOS Accessibility editable-focus observation and Unicode CGEvent text injection
- correlate remote pointer-up locations with editable AX ancestors, including browser web inputs
- ignore app-activation focus restores unrelated to the remote click
- generalize the Windows text-input decision API with compatibility aliases

## Validation

- `dart format --set-exit-if-changed lib/ test/ example/lib/ example/test/`
- `flutter test` (13 passed)
- `./build.sh --macos --dmg` in CloudPlayPlus client (Release build and Developer ID signing passed)
- full `flutter analyze` has only the repository's existing example lints; no analyzer errors