### PR TITLE
fix(macos): detect hidden host cursor

### DIFF
--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -293,6 +293,29 @@ class RunnerTests: XCTestCase {
     )
   }
 
+  func testCursorVisibilityCombinesWindowServerAndBitmapSignals() {
+    XCTAssertFalse(HardwareSimulatorPlugin.combinedCursorVisibility(
+      windowServerVisible: false,
+      cursorImageIsFullyTransparent: false
+    ))
+    XCTAssertFalse(HardwareSimulatorPlugin.combinedCursorVisibility(
+      windowServerVisible: false,
+      cursorImageIsFullyTransparent: true
+    ))
+    XCTAssertFalse(HardwareSimulatorPlugin.combinedCursorVisibility(
+      windowServerVisible: true,
+      cursorImageIsFullyTransparent: true
+    ))
+    XCTAssertTrue(HardwareSimulatorPlugin.combinedCursorVisibility(
+      windowServerVisible: true,
+      cursorImageIsFullyTransparent: false
+    ))
+    XCTAssertTrue(HardwareSimulatorPlugin.combinedCursorVisibility(
+      windowServerVisible: true,
+      cursorImageIsFullyTransparent: nil
+    ))
+  }
+
   private func makeCursorImage(alphaValues: [UInt8]) throws -> NSImage {
     let bitmapRep = try XCTUnwrap(NSBitmapImageRep(
       bitmapDataPlanes: nil,

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -253,6 +253,74 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(readUInt32BE(bytes, offset: 17), encoded.hash)
   }
 
+  func testCursorVisibilityTreatsFullyTransparentBitmapAsHidden() throws {
+    let image = try makeCursorImage(alphaValues: [0, 0, 0, 0])
+
+    XCTAssertEqual(
+      HardwareSimulatorPlugin.cursorImageIsFullyTransparent(image),
+      true
+    )
+  }
+
+  func testCursorVisibilityTreatsAnyNonzeroAlphaAsVisible() throws {
+    let image = try makeCursorImage(alphaValues: [0, 0, 1, 0])
+
+    XCTAssertEqual(
+      HardwareSimulatorPlugin.cursorImageIsFullyTransparent(image),
+      false
+    )
+  }
+
+  func testCursorVisibilityTreatsOpaqueBitmapWithoutAlphaAsVisible() throws {
+    let bitmapRep = try XCTUnwrap(NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: 1,
+      pixelsHigh: 1,
+      bitsPerSample: 8,
+      samplesPerPixel: 3,
+      hasAlpha: false,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    ))
+    let image = NSImage(size: NSSize(width: 1, height: 1))
+    image.addRepresentation(bitmapRep)
+
+    XCTAssertEqual(
+      HardwareSimulatorPlugin.cursorImageIsFullyTransparent(image),
+      false
+    )
+  }
+
+  private func makeCursorImage(alphaValues: [UInt8]) throws -> NSImage {
+    let bitmapRep = try XCTUnwrap(NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: alphaValues.count,
+      pixelsHigh: 1,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    ))
+    let bitmapData = try XCTUnwrap(bitmapRep.bitmapData)
+    let bytesPerPixel = bitmapRep.bitsPerPixel / 8
+    let alphaOffset = bitmapRep.bitmapFormat.contains(.alphaFirst)
+      ? 0
+      : bytesPerPixel - 1
+    for (x, alpha) in alphaValues.enumerated() {
+      bitmapData[x * bytesPerPixel + alphaOffset] = alpha
+    }
+    let image = NSImage(
+      size: NSSize(width: alphaValues.count, height: 1)
+    )
+    image.addRepresentation(bitmapRep)
+    return image
+  }
+
   private func readUInt32BE(_ bytes: [UInt8], offset: Int) -> UInt32 {
     bytes[offset..<offset + 4].reduce(0) { ($0 << 8) | UInt32($1) }
   }

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -2389,19 +2389,75 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return (messageHash, Data(bytes))
   }
 
+  static func cursorImageIsFullyTransparent(_ image: NSImage) -> Bool? {
+    var inspectedRepresentation = false
+    for case let bitmapRep as NSBitmapImageRep in image.representations {
+      guard bitmapRep.pixelsWide > 0, bitmapRep.pixelsHigh > 0 else {
+        continue
+      }
+      guard bitmapRep.hasAlpha else { return false }
+      if let transparent = bitmapRepresentationIsFullyTransparent(bitmapRep) {
+        inspectedRepresentation = true
+        if !transparent { return false }
+      }
+    }
+    return inspectedRepresentation ? true : nil
+  }
+
+  private static func bitmapRepresentationIsFullyTransparent(
+    _ bitmapRep: NSBitmapImageRep
+  ) -> Bool? {
+    if bitmapRep.bitsPerSample == 8,
+       !bitmapRep.isPlanar,
+       let bitmapData = bitmapRep.bitmapData {
+      let bytesPerPixel = bitmapRep.bitsPerPixel / 8
+      guard bytesPerPixel > 0 else { return nil }
+      let alphaOffset = bitmapRep.bitmapFormat.contains(.alphaFirst)
+        ? 0
+        : bytesPerPixel - 1
+
+      for y in 0..<bitmapRep.pixelsHigh {
+        let row = bitmapData.advanced(by: y * bitmapRep.bytesPerRow)
+        for x in 0..<bitmapRep.pixelsWide {
+          if row[x * bytesPerPixel + alphaOffset] != 0 {
+            return false
+          }
+        }
+      }
+      return true
+    }
+
+    var inspectedPixel = false
+    for y in 0..<bitmapRep.pixelsHigh {
+      for x in 0..<bitmapRep.pixelsWide {
+        guard let color = bitmapRep.colorAt(x: x, y: y) else { continue }
+        inspectedPixel = true
+        if color.alphaComponent > 0 { return false }
+      }
+    }
+    return inspectedPixel ? true : nil
+  }
+
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   private static func cursorVisibilityValue(_ rawValue: Int32?) -> Bool? {
     return rawValue.map { $0 != 0 }
   }
 
   private func currentSystemCursorVisibility() -> Bool {
+    let windowServerVisible: Bool
     if let slCursorIsVisible = resolveSLCursorIsVisibleFunction() {
-      return Self.cursorVisibilityValue(slCursorIsVisible()) ?? true
+      windowServerVisible =
+        Self.cursorVisibilityValue(slCursorIsVisible()) ?? true
+    } else if let cgCursorIsVisible = resolveCGCursorIsVisibleFunction() {
+      windowServerVisible =
+        Self.cursorVisibilityValue(cgCursorIsVisible()) ?? true
+    } else {
+      windowServerVisible = true
     }
-    guard let cgCursorIsVisible = resolveCGCursorIsVisibleFunction() else {
-      return true
-    }
-    return Self.cursorVisibilityValue(cgCursorIsVisible()) ?? true
+    guard windowServerVisible else { return false }
+
+    guard let cursorImage = NSCursor.currentSystem?.image else { return true }
+    return !(Self.cursorImageIsFullyTransparent(cursorImage) ?? false)
   }
 
   private func sendCursorInvisible(callbackID: Int) {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -102,6 +102,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   deinit {
     stopTrackpadScrollCapture()
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    stopCursorVisibilityTimer()
     stopMacOSTextInputDecisionCapture()
     if let cursorVisibilityProcessHandle {
       dlclose(cursorVisibilityProcessHandle)
@@ -2279,6 +2280,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   var mouseMovedMonitor: Any?
   var cursorPositionMonitor: Any?
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  var cursorVisibilityTimer: DispatchSourceTimer?
   var lastCursorVisible: Bool?
 #endif
   var previousCursorImageHashes: String = ""
@@ -2301,6 +2303,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
   ]
   static let cursorTransitionProbeDelaysMs = [16, 50]
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  static let cursorVisibilityPollIntervalMs = 200
+
   private typealias CGCursorIsVisibleFunction = @convention(c) () -> Int32
   private var cgCursorIsVisibleFunction: CGCursorIsVisibleFunction?
   private var cgCursorIsVisibleLookupAttempted = false
@@ -2430,6 +2434,30 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     guard !cursorChangedCallbacks.isEmpty else { return }
 
     updateCursorVisibility(currentSystemCursorVisibility())
+  }
+
+  private func startCursorVisibilityTimer() {
+    guard cursorVisibilityTimer == nil else { return }
+
+    let intervalMs = Self.cursorVisibilityPollIntervalMs
+    let timer = DispatchSource.makeTimerSource(queue: .main)
+    timer.schedule(
+      deadline: .now() + .milliseconds(intervalMs),
+      repeating: .milliseconds(intervalMs),
+      leeway: .milliseconds(25)
+    )
+    timer.setEventHandler { [weak self] in
+      self?.pollCursorVisibility()
+    }
+    cursorVisibilityTimer = timer
+    timer.resume()
+  }
+
+  private func stopCursorVisibilityTimer() {
+    cursorVisibilityTimer?.setEventHandler {}
+    cursorVisibilityTimer?.cancel()
+    cursorVisibilityTimer = nil
+    lastCursorVisible = nil
   }
 
   private func updateCursorVisibilityAfterInjectedMouseMove() {
@@ -3752,6 +3780,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           } else {
             updateCursorVisibility(visible)
           }
+          startCursorVisibilityTimer()
 #endif
          }
       else {
@@ -3765,7 +3794,7 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           cursorHashesByCallback.removeValue(forKey: callbackID)
           if cursorChangedCallbacks.count == 0{
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
-              lastCursorVisible = nil
+              stopCursorVisibilityTimer()
 #endif
               if let monitor = mouseMovedMonitor {
                NSEvent.removeMonitor(monitor)

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -2404,6 +2404,13 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return inspectedRepresentation ? true : nil
   }
 
+  static func combinedCursorVisibility(
+    windowServerVisible: Bool,
+    cursorImageIsFullyTransparent: Bool?
+  ) -> Bool {
+    return windowServerVisible && cursorImageIsFullyTransparent != true
+  }
+
   private static func bitmapRepresentationIsFullyTransparent(
     _ bitmapRep: NSBitmapImageRep
   ) -> Bool? {
@@ -2457,7 +2464,11 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     guard windowServerVisible else { return false }
 
     guard let cursorImage = NSCursor.currentSystem?.image else { return true }
-    return !(Self.cursorImageIsFullyTransparent(cursorImage) ?? false)
+    return Self.combinedCursorVisibility(
+      windowServerVisible: windowServerVisible,
+      cursorImageIsFullyTransparent:
+        Self.cursorImageIsFullyTransparent(cursorImage)
+    )
   }
 
   private func sendCursorInvisible(callbackID: Int) {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -6,6 +6,9 @@ import ApplicationServices
 import Darwin
 
 class CursorConstants {    
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  static let cursorInvisible = 1
+#endif
   static let cursorVisible = 2
   static let cursorUpdatedDefault = 3    
   static let cursorUpdatedImage = 4    
@@ -100,8 +103,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     stopTrackpadScrollCapture()
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
     stopMacOSTextInputDecisionCapture()
-#endif
-#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    if let cursorVisibilityProcessHandle {
+      dlclose(cursorVisibilityProcessHandle)
+    }
     if let macTerminationObserver {
       NotificationCenter.default.removeObserver(macTerminationObserver)
     }
@@ -1932,6 +1936,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           clickCount: 0,
           screenId: screenId
       )
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+      updateCursorVisibilityAfterInjectedMouseMove()
+#endif
   }
 
   func performMouseMoveRelative(dx: Double, dy: Double, screenId: Int) {
@@ -1954,6 +1961,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
               clickCount: 0,
               screenId: screenId
           )
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+          updateCursorVisibilityAfterInjectedMouseMove()
+#endif
       }
   }
 
@@ -2206,6 +2216,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
                              mouseCursorPosition: CGPoint(x: targetX, y: targetY), 
                              mouseButton: .left)
       moveEvent?.post(tap: .cghidEventTap)
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+      updateCursorVisibilityAfterInjectedMouseMove()
+#endif
   }
 
   private func cursorLocationInQuartzCoordinates(
@@ -2265,6 +2278,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   var mouseMovedMonitor: Any?
   var cursorPositionMonitor: Any?
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  var lastCursorVisible: Bool?
+#endif
   var previousCursorImageHashes: String = ""
   var cursorChangedCallbacks = Set<Int>()
   var cursorPositionCallbacks = Set<Int>()
@@ -2284,6 +2300,16 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     .otherMouseUp,
   ]
   static let cursorTransitionProbeDelaysMs = [16, 50]
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private typealias CGCursorIsVisibleFunction = @convention(c) () -> Int32
+  private var cgCursorIsVisibleFunction: CGCursorIsVisibleFunction?
+  private var cgCursorIsVisibleLookupAttempted = false
+  private var cursorVisibilityProcessHandle: UnsafeMutableRawPointer?
+
+  private typealias SLCursorIsVisibleFunction = @convention(c) () -> Int32
+  private var slCursorIsVisibleFunction: SLCursorIsVisibleFunction?
+  private var slCursorIsVisibleLookupAttempted = false
+#endif
 
   func JSHash(buffer: [UInt8], size: Int) -> UInt32 {
     var hash: UInt32 = 1315423911
@@ -2358,6 +2384,93 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     bytes.append(contentsOf: pixels)
     return (messageHash, Data(bytes))
   }
+
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+  private static func cursorVisibilityValue(_ rawValue: Int32?) -> Bool? {
+    return rawValue.map { $0 != 0 }
+  }
+
+  private func currentSystemCursorVisibility() -> Bool {
+    if let slCursorIsVisible = resolveSLCursorIsVisibleFunction() {
+      return Self.cursorVisibilityValue(slCursorIsVisible()) ?? true
+    }
+    guard let cgCursorIsVisible = resolveCGCursorIsVisibleFunction() else {
+      return true
+    }
+    return Self.cursorVisibilityValue(cgCursorIsVisible()) ?? true
+  }
+
+  private func sendCursorInvisible(callbackID: Int) {
+    methodChannel?.invokeMethod("onCursorImageMessage", arguments: [
+      "callbackID": callbackID,
+      "message": CursorConstants.cursorInvisible,
+      "msg_info": 0,
+      "cursorImage": FlutterStandardTypedData.init(bytes: Data([]))
+    ])
+  }
+
+  private func sendCursorVisibility(callbackID: Int, visible: Bool) {
+    if visible {
+      sendCursorImagePosition(callbackID: callbackID)
+    } else {
+      sendCursorInvisible(callbackID: callbackID)
+    }
+  }
+
+  private func updateCursorVisibility(_ visible: Bool) {
+    guard lastCursorVisible != visible else { return }
+
+    lastCursorVisible = visible
+    for callbackID in cursorChangedCallbacks {
+      sendCursorVisibility(callbackID: callbackID, visible: visible)
+    }
+  }
+
+  private func pollCursorVisibility() {
+    guard !cursorChangedCallbacks.isEmpty else { return }
+
+    updateCursorVisibility(currentSystemCursorVisibility())
+  }
+
+  private func updateCursorVisibilityAfterInjectedMouseMove() {
+    pollCursorVisibility()
+  }
+
+  private func resolveCGCursorIsVisibleFunction() -> CGCursorIsVisibleFunction? {
+    if cgCursorIsVisibleLookupAttempted {
+      return cgCursorIsVisibleFunction
+    }
+    cgCursorIsVisibleLookupAttempted = true
+
+    guard let processHandle = dlopen(nil, RTLD_LAZY) else { return nil }
+    guard let symbol = dlsym(processHandle, "CGCursorIsVisible") else {
+      dlclose(processHandle)
+      return nil
+    }
+    cursorVisibilityProcessHandle = processHandle
+    cgCursorIsVisibleFunction = unsafeBitCast(
+      symbol,
+      to: CGCursorIsVisibleFunction.self
+    )
+    return cgCursorIsVisibleFunction
+  }
+
+  private func resolveSLCursorIsVisibleFunction() -> SLCursorIsVisibleFunction? {
+    if slCursorIsVisibleLookupAttempted {
+      return slCursorIsVisibleFunction
+    }
+    slCursorIsVisibleLookupAttempted = true
+
+    if let skyLight = loadMacSkyLight(),
+       let symbol = dlsym(skyLight, "SLCursorIsVisible") {
+      slCursorIsVisibleFunction = unsafeBitCast(
+        symbol,
+        to: SLCursorIsVisibleFunction.self
+      )
+    }
+    return slCursorIsVisibleFunction
+  }
+#endif
 
   private func handleCursorMonitorEvent(_ event: NSEvent) {
     checkMouseCursor()
@@ -3626,9 +3739,20 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
                   ]
                   methodChannel?.invokeMethod("onCursorImageMessage", arguments: message)
                   markCursorHashSeen(callbackID, messageHash)
+#if !CLOUDPLAYPLUS_DMG_DISTRIBUTION
                   sendCursorImagePosition(callbackID: callbackID)
+#endif
               }
           }
+
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+          let visible = currentSystemCursorVisibility()
+          if lastCursorVisible == visible {
+            sendCursorVisibility(callbackID: callbackID, visible: visible)
+          } else {
+            updateCursorVisibility(visible)
+          }
+#endif
          }
       else {
         result(FlutterError(code: "BAD_ARGS", message: "Missing or incorrect arguments for hookCursorImage", details: nil))
@@ -3640,6 +3764,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
           hookAllCursorImage.removeValue(forKey: callbackID)
           cursorHashesByCallback.removeValue(forKey: callbackID)
           if cursorChangedCallbacks.count == 0{
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+              lastCursorVisible = nil
+#endif
               if let monitor = mouseMovedMonitor {
                NSEvent.removeMonitor(monitor)
                mouseMovedMonitor = nil


### PR DESCRIPTION
## Summary

- detect DMG host cursor visibility by combining WindowServer visibility with the current NSCursor bitmap alpha
- prefer `SLCursorIsVisible`, falling back to `CGCursorIsVisible`; treat a fully transparent current cursor bitmap as hidden even when both getters report visible
- send an initial visibility snapshot, re-check after injected remote mouse movement, and run a 200 ms safety poll only while cursor hooks are active
- compile the visibility symbols and behavior out of non-DMG/App Store builds

## Verification

- macOS native tests: 18/18 passed, including transparent/visible bitmaps and combined-signal precedence
- `./build.sh --macos --dmg` passed at implementation head `8d0093b`; Developer ID signing verification succeeded
- verified the non-DMG framework contains neither visibility symbol
- release preview: `build/macos/Build/Products/Release/cloudplayplus.app` in the parent client checkout

## Test context

- Slay the Spire changes the WindowServer cursor hide/show count without changing cursor seed or bitmap
- Chrome/Bilibili keeps both visibility getters at 1 but switches to a fully transparent 1x1 cursor bitmap

The combined rule covers both observed paths: hidden when WindowServer reports hidden or the current cursor bitmap is fully transparent.