### PR TITLE
fix(macos): restore visibility on cursor texture updates

### DIFF
--- a/example/lib/macos_cursor_visibility_demo.dart
+++ b/example/lib/macos_cursor_visibility_demo.dart
@@ -1,0 +1,224 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:hardware_simulator/hardware_simulator.dart';
+
+void main() {
+  runApp(const CursorVisibilityDemoApp());
+}
+
+class CursorVisibilityDemoApp extends StatelessWidget {
+  const CursorVisibilityDemoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        brightness: Brightness.dark,
+        colorSchemeSeed: Colors.blue,
+        useMaterial3: true,
+      ),
+      home: const CursorVisibilityDemoPage(),
+    );
+  }
+}
+
+enum _ViewerCursorState { waiting, locked, unlocked }
+
+class CursorVisibilityDemoPage extends StatefulWidget {
+  const CursorVisibilityDemoPage({super.key});
+
+  @override
+  State<CursorVisibilityDemoPage> createState() =>
+      _CursorVisibilityDemoPageState();
+}
+
+class _CursorVisibilityDemoPageState extends State<CursorVisibilityDemoPage> {
+  static const _callbackId = 49001;
+  static const _maxEvents = 100;
+
+  final List<String> _events = <String>[];
+  _ViewerCursorState _state = _ViewerCursorState.waiting;
+  int _textureUpdateCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    HardwareSimulator.addCursorImageUpdated(
+      _handleCursorMessage,
+      _callbackId,
+      true,
+    );
+  }
+
+  @override
+  void dispose() {
+    HardwareSimulator.removeCursorImageUpdated(_callbackId);
+    super.dispose();
+  }
+
+  void _handleCursorMessage(
+    int message,
+    int messageInfo,
+    Uint8List cursorImage,
+  ) {
+    if (!mounted) return;
+
+    switch (message) {
+      case HardwareSimulator.CURSOR_INVISIBLE:
+        _setCursorState(_ViewerCursorState.locked, 'LOCKED  cursor invisible');
+      case HardwareSimulator.CURSOR_VISIBLE:
+        final position = _decodePosition(cursorImage);
+        final suffix = position == null
+            ? ''
+            : '  screen=$messageInfo x=${position.$1} y=${position.$2}';
+        _setCursorState(
+          _ViewerCursorState.unlocked,
+          'UNLOCKED  cursor visible$suffix',
+        );
+      case HardwareSimulator.CURSOR_UPDATED_IMAGE:
+        _recordTexture('bitmap hash=$messageInfo');
+      case HardwareSimulator.CURSOR_UPDATED_DEFAULT:
+        _recordTexture('system cursor id=$messageInfo');
+      case HardwareSimulator.CURSOR_UPDATED_CACHED:
+        _recordTexture('cached hash=$messageInfo');
+    }
+  }
+
+  (String, String)? _decodePosition(Uint8List bytes) {
+    if (bytes.length < 4) return null;
+    final data = ByteData.sublistView(bytes);
+    final x = data.getUint16(0, Endian.little) / 65535.0;
+    final y = data.getUint16(2, Endian.little) / 65535.0;
+    return (
+      '${(x * 100).toStringAsFixed(1)}%',
+      '${(y * 100).toStringAsFixed(1)}%',
+    );
+  }
+
+  void _setCursorState(_ViewerCursorState state, String event) {
+    setState(() {
+      _state = state;
+      _appendEvent(event);
+    });
+  }
+
+  void _recordTexture(String detail) {
+    setState(() {
+      _textureUpdateCount++;
+      _appendEvent('TEXTURE  $detail');
+    });
+  }
+
+  void _appendEvent(String event) {
+    final now = DateTime.now();
+    final time = '${_twoDigits(now.hour)}:${_twoDigits(now.minute)}:'
+        '${_twoDigits(now.second)}.${now.millisecond.toString().padLeft(3, '0')}';
+    _events.insert(0, '$time  $event');
+    if (_events.length > _maxEvents) {
+      _events.removeRange(_maxEvents, _events.length);
+    }
+  }
+
+  String _twoDigits(int value) => value.toString().padLeft(2, '0');
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color, icon) = switch (_state) {
+      _ViewerCursorState.waiting => (
+          'WAITING',
+          Colors.blueGrey,
+          Icons.hourglass_top
+        ),
+      _ViewerCursorState.locked => ('LOCKED', Colors.red, Icons.lock),
+      _ViewerCursorState.unlocked => (
+          'UNLOCKED',
+          Colors.green,
+          Icons.lock_open
+        ),
+    };
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('macOS Host Cursor Visibility Monitor'),
+        actions: [
+          TextButton.icon(
+            onPressed: () => setState(_events.clear),
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('Clear'),
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.16),
+                border: Border.all(color: color, width: 2),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 22),
+                child: Column(
+                  children: [
+                    Icon(icon, size: 46, color: color),
+                    const SizedBox(height: 8),
+                    Text(
+                      label,
+                      style:
+                          Theme.of(context).textTheme.headlineMedium?.copyWith(
+                                color: color,
+                                fontWeight: FontWeight.bold,
+                              ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text('Texture updates: $_textureUpdateCount'),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '这个状态等价于 Viewer 的动态鼠标锁定状态。把窗口留在后台，'
+              '依次测试输入文字、移动远程鼠标、B 站视频和游戏；观察事件顺序。',
+            ),
+            const SizedBox(height: 16),
+            Text('Events', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Expanded(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Colors.black26,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: _events.isEmpty
+                    ? const Center(child: Text('Waiting for cursor events…'))
+                    : SelectionArea(
+                        child: ListView.builder(
+                          padding: const EdgeInsets.all(12),
+                          itemCount: _events.length,
+                          itemBuilder: (context, index) => Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 2),
+                            child: Text(
+                              _events[index],
+                              style: const TextStyle(
+                                fontFamily: 'monospace',
+                                fontSize: 13,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -316,6 +316,54 @@ class RunnerTests: XCTestCase {
     ))
   }
 
+  func testCursorVisibilityKeepsNontransparentTextureEvidenceWhileGetterIsStale() {
+    let result = HardwareSimulatorPlugin.reconciledCursorVisibility(
+      windowServerVisible: false,
+      previousWindowServerVisible: false,
+      cursorTextureProvesVisible: true,
+      cursorImageIsFullyTransparent: false
+    )
+
+    XCTAssertTrue(result.visible)
+    XCTAssertTrue(result.cursorTextureProvesVisible)
+  }
+
+  func testCursorVisibilityLetsTransparentTextureOverrideVisibleEvidence() {
+    let result = HardwareSimulatorPlugin.reconciledCursorVisibility(
+      windowServerVisible: false,
+      previousWindowServerVisible: false,
+      cursorTextureProvesVisible: true,
+      cursorImageIsFullyTransparent: true
+    )
+
+    XCTAssertFalse(result.visible)
+    XCTAssertFalse(result.cursorTextureProvesVisible)
+  }
+
+  func testCursorVisibilityUsesNewWindowServerHiddenTransition() {
+    let result = HardwareSimulatorPlugin.reconciledCursorVisibility(
+      windowServerVisible: false,
+      previousWindowServerVisible: true,
+      cursorTextureProvesVisible: true,
+      cursorImageIsFullyTransparent: false
+    )
+
+    XCTAssertFalse(result.visible)
+    XCTAssertFalse(result.cursorTextureProvesVisible)
+  }
+
+  func testCursorVisibilityClearsTextureEvidenceWhenGetterRecovers() {
+    let result = HardwareSimulatorPlugin.reconciledCursorVisibility(
+      windowServerVisible: true,
+      previousWindowServerVisible: false,
+      cursorTextureProvesVisible: true,
+      cursorImageIsFullyTransparent: false
+    )
+
+    XCTAssertTrue(result.visible)
+    XCTAssertFalse(result.cursorTextureProvesVisible)
+  }
+
   private func makeCursorImage(alphaValues: [UInt8]) throws -> NSImage {
     let bitmapRep = try XCTUnwrap(NSBitmapImageRep(
       bitmapDataPlanes: nil,

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -341,15 +341,25 @@ class RunnerTests: XCTestCase {
   }
 
   func testCursorVisibilityUsesNewWindowServerHiddenTransition() {
-    let result = HardwareSimulatorPlugin.reconciledCursorVisibility(
+    let textureUpdate = HardwareSimulatorPlugin.reconciledCursorVisibility(
       windowServerVisible: false,
       previousWindowServerVisible: true,
       cursorTextureProvesVisible: true,
       cursorImageIsFullyTransparent: false
     )
 
-    XCTAssertFalse(result.visible)
-    XCTAssertFalse(result.cursorTextureProvesVisible)
+    XCTAssertFalse(textureUpdate.visible)
+    XCTAssertFalse(textureUpdate.cursorTextureProvesVisible)
+
+    let followingPoll = HardwareSimulatorPlugin.reconciledCursorVisibility(
+      windowServerVisible: false,
+      previousWindowServerVisible: false,
+      cursorTextureProvesVisible: textureUpdate.cursorTextureProvesVisible,
+      cursorImageIsFullyTransparent: false
+    )
+
+    XCTAssertFalse(followingPoll.visible)
+    XCTAssertFalse(followingPoll.cursorTextureProvesVisible)
   }
 
   func testCursorVisibilityClearsTextureEvidenceWhenGetterRecovers() {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -2500,16 +2500,18 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 
   private func updateCursorVisibilityAfterTextureChange(_ image: NSImage) {
     let cursorImageIsFullyTransparent = Self.cursorImageIsFullyTransparent(image)
-    if cursorImageIsFullyTransparent == true {
-      cursorTextureProvesVisible = false
-      updateCursorVisibility(false)
-      return
-    }
-    guard cursorImageIsFullyTransparent == false else { return }
+    guard cursorImageIsFullyTransparent != nil else { return }
 
-    lastWindowServerCursorVisible = currentWindowServerCursorVisibility()
-    cursorTextureProvesVisible = true
-    updateCursorVisibility(true)
+    let windowServerVisible = currentWindowServerCursorVisibility()
+    let result = Self.reconciledCursorVisibility(
+      windowServerVisible: windowServerVisible,
+      previousWindowServerVisible: lastWindowServerCursorVisible,
+      cursorTextureProvesVisible: cursorImageIsFullyTransparent == false,
+      cursorImageIsFullyTransparent: cursorImageIsFullyTransparent
+    )
+    lastWindowServerCursorVisible = windowServerVisible
+    cursorTextureProvesVisible = result.cursorTextureProvesVisible
+    updateCursorVisibility(result.visible)
   }
 
   private func sendCursorInvisible(callbackID: Int) {

--- a/macos/Classes/HardwareSimulatorPlugin.swift
+++ b/macos/Classes/HardwareSimulatorPlugin.swift
@@ -2282,6 +2282,10 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
 #if CLOUDPLAYPLUS_DMG_DISTRIBUTION
   var cursorVisibilityTimer: DispatchSourceTimer?
   var lastCursorVisible: Bool?
+  var lastWindowServerCursorVisible: Bool?
+  // 远程注入移动后 WindowServer getter 可能一直停留在 false；新的非透明纹理
+  // 证明系统已经重新绘制光标，不能被同一个滞留值立即覆盖。
+  var cursorTextureProvesVisible = false
 #endif
   var previousCursorImageHashes: String = ""
   var cursorChangedCallbacks = Set<Int>()
@@ -2411,6 +2415,24 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return windowServerVisible && cursorImageIsFullyTransparent != true
   }
 
+  static func reconciledCursorVisibility(
+    windowServerVisible: Bool,
+    previousWindowServerVisible: Bool?,
+    cursorTextureProvesVisible: Bool,
+    cursorImageIsFullyTransparent: Bool?
+  ) -> (visible: Bool, cursorTextureProvesVisible: Bool) {
+    if cursorImageIsFullyTransparent == true {
+      return (false, false)
+    }
+    if windowServerVisible {
+      return (true, false)
+    }
+    if previousWindowServerVisible == nil || previousWindowServerVisible == true {
+      return (false, false)
+    }
+    return (cursorTextureProvesVisible, cursorTextureProvesVisible)
+  }
+
   private static func bitmapRepresentationIsFullyTransparent(
     _ bitmapRep: NSBitmapImageRep
   ) -> Bool? {
@@ -2450,25 +2472,44 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     return rawValue.map { $0 != 0 }
   }
 
-  private func currentSystemCursorVisibility() -> Bool {
-    let windowServerVisible: Bool
+  private func currentWindowServerCursorVisibility() -> Bool {
     if let slCursorIsVisible = resolveSLCursorIsVisibleFunction() {
-      windowServerVisible =
-        Self.cursorVisibilityValue(slCursorIsVisible()) ?? true
+      return Self.cursorVisibilityValue(slCursorIsVisible()) ?? true
     } else if let cgCursorIsVisible = resolveCGCursorIsVisibleFunction() {
-      windowServerVisible =
-        Self.cursorVisibilityValue(cgCursorIsVisible()) ?? true
-    } else {
-      windowServerVisible = true
+      return Self.cursorVisibilityValue(cgCursorIsVisible()) ?? true
     }
-    guard windowServerVisible else { return false }
+    return true
+  }
 
-    guard let cursorImage = NSCursor.currentSystem?.image else { return true }
-    return Self.combinedCursorVisibility(
+  private func currentSystemCursorVisibility() -> Bool {
+    let windowServerVisible = currentWindowServerCursorVisibility()
+    let cursorImage = NSCursor.currentSystem?.image
+    let cursorImageIsFullyTransparent = cursorImage.flatMap {
+      Self.cursorImageIsFullyTransparent($0)
+    }
+    let result = Self.reconciledCursorVisibility(
       windowServerVisible: windowServerVisible,
-      cursorImageIsFullyTransparent:
-        Self.cursorImageIsFullyTransparent(cursorImage)
+      previousWindowServerVisible: lastWindowServerCursorVisible,
+      cursorTextureProvesVisible: cursorTextureProvesVisible,
+      cursorImageIsFullyTransparent: cursorImageIsFullyTransparent
     )
+    lastWindowServerCursorVisible = windowServerVisible
+    cursorTextureProvesVisible = result.cursorTextureProvesVisible
+    return result.visible
+  }
+
+  private func updateCursorVisibilityAfterTextureChange(_ image: NSImage) {
+    let cursorImageIsFullyTransparent = Self.cursorImageIsFullyTransparent(image)
+    if cursorImageIsFullyTransparent == true {
+      cursorTextureProvesVisible = false
+      updateCursorVisibility(false)
+      return
+    }
+    guard cursorImageIsFullyTransparent == false else { return }
+
+    lastWindowServerCursorVisible = currentWindowServerCursorVisibility()
+    cursorTextureProvesVisible = true
+    updateCursorVisibility(true)
   }
 
   private func sendCursorInvisible(callbackID: Int) {
@@ -2525,6 +2566,8 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     cursorVisibilityTimer?.cancel()
     cursorVisibilityTimer = nil
     lastCursorVisible = nil
+    lastWindowServerCursorVisible = nil
+    cursorTextureProvesVisible = false
   }
 
   private func updateCursorVisibilityAfterInjectedMouseMove() {
@@ -2720,6 +2763,9 @@ public class HardwareSimulatorPlugin: NSObject, FlutterPlugin {
     if(cursorImageHashes == previousCursorImageHashes){
         return;
     }
+#if CLOUDPLAYPLUS_DMG_DISTRIBUTION
+    updateCursorVisibilityAfterTextureChange(cursorImage)
+#endif
     //system default
     if let cursorIndex = defaultCursorHasher?.getHashMap()[cursorImageHashes] {
         var updatedAllCallbacks = true


### PR DESCRIPTION
## Summary

- treat a new nontransparent macOS cursor texture as positive visibility evidence when deprecated WindowServer getters remain stale
- keep transparent textures and fresh visible-to-hidden getter transitions as explicit hidden evidence
- add state-reconciliation regression tests and a focused macOS LOCKED/UNLOCKED monitor demo

## Verification

- user reproduced the Codex remote-typing case and confirmed `TEXTURE → UNLOCKED` is correct
- macOS RunnerTests: passed
- release demo: `example/build/macos/Build/Products/Release/hardware_simulator_example.app`

DMG-only behavior; non-DMG builds do not use the private visibility symbols.